### PR TITLE
Handle missing target body parts in damage calc

### DIFF
--- a/LlmGame/Assets/Script/DamageCalculator.cs
+++ b/LlmGame/Assets/Script/DamageCalculator.cs
@@ -103,6 +103,7 @@ public class DamageCalculator : MonoBehaviour
         if (selectedTargetParts == null || selectedTargetParts.Count == 0)
         {
             Debug.LogWarning("⚠️ No selected body parts on target.");
+            return new DamageResult(0f, 0f, 0f);
         }
 
         // 🛡️ 1. Income WeakPoints (from target)
@@ -263,6 +264,7 @@ public class DamageCalculator : MonoBehaviour
         if (selectedTargetParts == null || selectedTargetParts.Count == 0)
         {
             Debug.LogWarning("⚠️ No selected body parts on target.");
+            return new DamageResult(0f, 0f, 0f);
         }
 
         // 🛡️ Income weak points from target


### PR DESCRIPTION
## Summary
- prevent damage calculation from proceeding when no target body parts are selected
- avoids null references and divide-by-zero issues when target selection is empty

## Testing
- `mcs LlmGame/Assets/Script/DamageCalculator.cs` *(fails: command not found)*
- `apt-get update` *(fails: repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689456f0ac988322b6a34bee24f732b0