### PR TITLE
Add toxic armor items and status mechanics

### DIFF
--- a/LlmGame/Assets/Script/Character.cs
+++ b/LlmGame/Assets/Script/Character.cs
@@ -264,6 +264,23 @@ public class Character : MonoBehaviour
 
     public void ApplyStatusEffect(TurnStatusEffect newEffect)
     {
+        Character source = newEffect.source;
+        if (source != null)
+        {
+            foreach (var itemData in source.equippedPassiveItems)
+            {
+                if (itemData.itemPrefab == null) continue;
+                if (itemData.itemPrefab.GetComponent<ToxicVisor>() != null)
+                {
+                    if (newEffect.effectType == StatusEffectType.Poison || newEffect.effectType == StatusEffectType.Radiation)
+                    {
+                        newEffect.remainingTurns += 1;
+                    }
+                    break;
+                }
+            }
+        }
+
         // Optional: merge with existing effect
         var existing = activeStatusEffects.Find(e => e.effectType == newEffect.effectType);
         if (existing != null)

--- a/LlmGame/Assets/Script/CharacterCombatHandler.cs
+++ b/LlmGame/Assets/Script/CharacterCombatHandler.cs
@@ -205,7 +205,7 @@ public class CharacterCombatHandler : MonoBehaviour
         // ☠️ Poison chance roll
         if (attacker.possibilityPool.Roll(StatusChanceType.Poison))
         {
-            TurnStatusEffect poison = new TurnStatusEffect(StatusEffectType.Poison, 3, 1);
+            TurnStatusEffect poison = new TurnStatusEffect(StatusEffectType.Poison, 3, 1, attacker);
             target.ApplyStatusEffect(poison);
 
             appliedEffects.Add($"inflicted Poison on {target.characterName}");

--- a/LlmGame/Assets/Script/DamageCalculator.cs
+++ b/LlmGame/Assets/Script/DamageCalculator.cs
@@ -188,6 +188,8 @@ public class DamageCalculator : MonoBehaviour
             reducedDamageBreakdown[kvp.Key] = reduced;
         }
 
+        battleManager.combatHandler.SaveLastDamageBreakdown(attacker, reducedDamageBreakdown);
+
         // 🎯 7. Final scaled damage
         float finalDamage = reducedDamageBreakdown.Values.Sum() + baseDamage;
         float scaledFinalDamage = Mathf.Max(0f, finalDamage * llmDamageModifier);
@@ -346,6 +348,8 @@ public class DamageCalculator : MonoBehaviour
             reducedDamageBreakdown[dt] = reduced;
             Debug.Log($"[Reduce] {dt}: -{reduction} => {reduced}");
         }
+
+        battleManager.combatHandler.SaveLastDamageBreakdown(attacker, reducedDamageBreakdown);
 
         // 6️⃣ Final damage value
         float finalDamage = reducedDamageBreakdown.Values.Sum() + baseDamage;

--- a/LlmGame/Assets/Script/Item/BiohazardReactor.cs
+++ b/LlmGame/Assets/Script/Item/BiohazardReactor.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+public class BiohazardReactor : MonoBehaviour, IPassiveItem, IDamageReaction
+{
+    private const float RESISTANCE = 0.2f; // 20%
+    private const float DEBUFF_CHANCE = 0.25f;
+
+    public void ApplyEffect(Character character)
+    {
+        // No immediate effect
+    }
+
+    public void OnBeforeDamage(Character source, Character target, ref int damage)
+    {
+        if (source == null || target == null) return;
+
+        var handler = Object.FindObjectOfType<CharacterCombatHandler>();
+        if (handler == null) return;
+
+        Dictionary<DamageType, float> breakdown = handler.GetLastDamageBreakdown(source);
+        if (breakdown == null || breakdown.Count == 0) return;
+
+        breakdown.TryGetValue(DamageType.Poison, out float chemical);
+        breakdown.TryGetValue(DamageType.Radiation, out float radiation);
+        float totalRelevant = chemical + radiation;
+        float total = 0f;
+        foreach (var v in breakdown.Values) total += v;
+        if (totalRelevant <= 0f || total <= 0f) return;
+
+        float ratio = totalRelevant / total;
+        int reduceAmount = Mathf.RoundToInt(damage * RESISTANCE * ratio);
+        damage = Mathf.Max(0, damage - reduceAmount);
+    }
+
+    public void OnAfterDamage(Character source, Character target, int finalDamage)
+    {
+        if (source == null || target == null) return;
+
+        Weapon weapon = source.rightHandWeapon ?? source.leftHandWeapon;
+        if (weapon == null || weapon.weaponType != WeaponType.Melee_Weapon) return;
+
+        if (Random.value <= DEBUFF_CHANCE)
+        {
+            var debuff = new TurnStatusEffect(StatusEffectType.Radiation, 1, 1, target);
+            source.ApplyStatusEffect(debuff);
+        }
+    }
+}
+

--- a/LlmGame/Assets/Script/Item/InjectorGauntlets.cs
+++ b/LlmGame/Assets/Script/Item/InjectorGauntlets.cs
@@ -1,0 +1,34 @@
+using UnityEngine;
+
+public class InjectorGauntlets : MonoBehaviour, IPassiveItem, IDamageReaction
+{
+    private const float STATUS_CHANCE = 0.5f;
+
+    public void ApplyEffect(Character character)
+    {
+        // No immediate effect
+    }
+
+    public void OnBeforeDamage(Character source, Character target, ref int damage) { }
+
+    public void OnAfterDamage(Character source, Character target, int finalDamage)
+    {
+        if (source == null || target == null) return;
+
+        Weapon weapon = source.rightHandWeapon ?? source.leftHandWeapon;
+        if (weapon == null || weapon.weaponType != WeaponType.Melee_Weapon) return;
+
+        if (Random.value <= STATUS_CHANCE)
+        {
+            var poison = new TurnStatusEffect(StatusEffectType.Poison, 3, 1, source);
+            target.ApplyStatusEffect(poison);
+        }
+
+        if (Random.value <= STATUS_CHANCE)
+        {
+            var radiation = new TurnStatusEffect(StatusEffectType.Radiation, 2, 1, source);
+            target.ApplyStatusEffect(radiation);
+        }
+    }
+}
+

--- a/LlmGame/Assets/Script/Item/ToxicVisor.cs
+++ b/LlmGame/Assets/Script/Item/ToxicVisor.cs
@@ -1,0 +1,16 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ToxicVisor : MonoBehaviour, IPassiveItem
+{
+    public void ApplyEffect(Character character)
+    {
+        // No immediate effect on equip
+    }
+
+    public void OnAfterDamage(Character source, Character target, int finalDamage) { }
+
+    public void OnBeforeDamage(Character source, Character target, ref int damage) { }
+}
+


### PR DESCRIPTION
## Summary
- Introduce Toxic Visor passive item
- Add Biohazard Reactor with chemical/radiation resistance and reactive radiation debuff
- Create Injector Gauntlets that add poison and radiation effects to melee attacks
- Track poison sources and extend poison/radiation durations when using Toxic Visor
- Preserve damage type breakdown for downstream armor effects

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689458d2fefc83228b436be1d8ebafe9