### PR TITLE
Add passive armor items with ranged bonuses

### DIFF
--- a/LlmGame/Assets/Script/DamageCalculator.cs
+++ b/LlmGame/Assets/Script/DamageCalculator.cs
@@ -155,14 +155,34 @@ public class DamageCalculator : MonoBehaviour
         float finalFeasibility = Mathf.Max(0f, feasibility + feasibilityModifierSum);
         float finalPotential = Mathf.Max(0f, potential + potentialModifierSum);
 
+        // 🔍 Check for Ghostscope Overlay (ignore feasibility/potential reduction with ranged weapons)
+        bool ignoreArmorPenalty = false;
+        Weapon activeWeapon = attacker is Player ap ? ap.rightHandWeapon ?? ap.leftHandWeapon : null;
+        if (activeWeapon != null && activeWeapon.weaponType == WeaponType.Ranged_Weapon)
+        {
+            foreach (var part in attacker.bodyParts)
+            {
+                var armor = part.equippedArmor;
+                if (armor != null && armor.itemBehaviorPrefab != null &&
+                    armor.itemBehaviorPrefab.GetComponent<GhostscopeOverlay>() != null)
+                {
+                    ignoreArmorPenalty = true;
+                    break;
+                }
+            }
+        }
+
         // 🛡️ 4. Apply armor reduction (target only)
         foreach (var part in selectedTargetParts)
         {
             var armor = part.equippedArmor;
             if (armor == null) continue;
 
-            finalFeasibility *= 1f - Mathf.Clamp01(armor.reduceFeasibility);
-            finalPotential *= 1f - Mathf.Clamp01(armor.reducePotentialDamage);
+            if (!ignoreArmorPenalty)
+            {
+                finalFeasibility *= 1f - Mathf.Clamp01(armor.reduceFeasibility);
+                finalPotential *= 1f - Mathf.Clamp01(armor.reducePotentialDamage);
+            }
         }
 
         // 🧠 5. LLM Scaling
@@ -334,13 +354,32 @@ public class DamageCalculator : MonoBehaviour
         float finalFeasibility = Mathf.Max(0f, feasibility + feasibilityModifierSum);
         float finalPotential = Mathf.Max(0f, potential + potentialModifierSum);
 
+        bool ignoreArmorPenalty = false;
+        Weapon activeWeapon = attacker is Player ap ? ap.rightHandWeapon ?? ap.leftHandWeapon : null;
+        if (activeWeapon != null && activeWeapon.weaponType == WeaponType.Ranged_Weapon)
+        {
+            foreach (var part in attacker.bodyParts)
+            {
+                var armor = part.equippedArmor;
+                if (armor != null && armor.itemBehaviorPrefab != null &&
+                    armor.itemBehaviorPrefab.GetComponent<GhostscopeOverlay>() != null)
+                {
+                    ignoreArmorPenalty = true;
+                    break;
+                }
+            }
+        }
+
         foreach (var part in selectedTargetParts)
         {
             ArmorData armor = part.equippedArmor;
             if (armor == null) continue;
 
-            finalFeasibility *= 1f - Mathf.Clamp01(armor.reduceFeasibility);
-            finalPotential *= 1f - Mathf.Clamp01(armor.reducePotentialDamage);
+            if (!ignoreArmorPenalty)
+            {
+                finalFeasibility *= 1f - Mathf.Clamp01(armor.reduceFeasibility);
+                finalPotential *= 1f - Mathf.Clamp01(armor.reducePotentialDamage);
+            }
         }
 
         // 4️⃣ Final scaling

--- a/LlmGame/Assets/Script/Item/CombatHUDProcessor.cs
+++ b/LlmGame/Assets/Script/Item/CombatHUDProcessor.cs
@@ -1,0 +1,50 @@
+using UnityEngine;
+
+public class CombatHUDProcessor : MonoBehaviour, IPassiveItem, ITurnListener, IDamageReaction
+{
+    private Character owner;
+    private bool usedThisTurn = false;
+    private const int bonusDamage = 20;
+
+    public void ApplyEffect(Character character)
+    {
+        owner = character;
+        Debug.Log("📡 Combat HUD Processor equipped: first ranged attack each turn deals +20 explosive damage.");
+    }
+
+    public void OnTurnStart(Character character)
+    {
+        if (character == owner)
+            usedThisTurn = false;
+    }
+
+    public void OnTurnEnd(Character character) { }
+
+    public void OnAfterDamage(Character source, Character target, int finalDamage)
+    {
+        if (usedThisTurn || source != owner || target == null)
+            return;
+
+        Weapon weapon = owner.rightHandWeapon ?? owner.leftHandWeapon;
+        if (weapon != null && weapon.weaponType == WeaponType.Ranged_Weapon)
+        {
+            target.TakeDamage(bonusDamage);
+
+            var handler = FindObjectOfType<CharacterCombatHandler>();
+            if (handler != null)
+            {
+                var breakdown = handler.GetLastDamageBreakdown(owner);
+                if (breakdown.ContainsKey(DamageType.Explosive))
+                    breakdown[DamageType.Explosive] += bonusDamage;
+                else
+                    breakdown[DamageType.Explosive] = bonusDamage;
+                handler.SaveLastDamageBreakdown(owner, breakdown);
+            }
+
+            usedThisTurn = true;
+            Debug.Log($"📡 Combat HUD Processor: dealt extra {bonusDamage} explosive damage.");
+        }
+    }
+
+    public void OnBeforeDamage(Character source, Character target, ref int damage) { }
+}

--- a/LlmGame/Assets/Script/Item/GhostscopeOverlay.cs
+++ b/LlmGame/Assets/Script/Item/GhostscopeOverlay.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+public class GhostscopeOverlay : MonoBehaviour, IPassiveItem
+{
+    public void ApplyEffect(Character character)
+    {
+        Debug.Log("👻 Ghostscope Overlay equipped: ranged attacks ignore feasibility and potential penalties from armor.");
+    }
+
+    public void OnAfterDamage(Character source, Character target, int finalDamage) { }
+    public void OnBeforeDamage(Character source, Character target, ref int damage) { }
+}

--- a/LlmGame/Assets/Script/Item/HawkEyeLens.cs
+++ b/LlmGame/Assets/Script/Item/HawkEyeLens.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+
+public class HawkEyeLens : MonoBehaviour, IPassiveItem
+{
+    [SerializeField] private float critBonus = 0.5f; // +50% Critical Chance
+
+    public void ApplyEffect(Character character)
+    {
+        if (character is Player player)
+        {
+            Weapon weapon = player.rightHandWeapon ?? player.leftHandWeapon;
+            if (weapon != null && weapon.weaponType == WeaponType.Ranged_Weapon)
+            {
+                player.possibilityPool.AddModifier(StatusChanceType.Critical, critBonus);
+                Debug.Log($"🎯 Hawk-Eye Lens equipped: +{critBonus * 100}% Critical Chance with ranged weapons.");
+            }
+        }
+    }
+
+    public void OnAfterDamage(Character source, Character target, int finalDamage) { }
+    public void OnBeforeDamage(Character source, Character target, ref int damage) { }
+}

--- a/LlmGame/Assets/Script/Item/RecoilStabilizerArmor.cs
+++ b/LlmGame/Assets/Script/Item/RecoilStabilizerArmor.cs
@@ -1,0 +1,38 @@
+using UnityEngine;
+
+public class RecoilStabilizerArmor : MonoBehaviour, IPassiveItem, IDamageReaction
+{
+    private Character owner;
+    private const int defenseBonus = 10;
+    private const int damageBonus = 10;
+
+    public void ApplyEffect(Character character)
+    {
+        owner = character;
+        Weapon weapon = GetWeapon();
+        if (weapon != null && weapon.weaponType == WeaponType.Ranged_Weapon)
+        {
+            character.defense += defenseBonus;
+            Debug.Log($"🦴 Recoil Stabilizer equipped: +{defenseBonus} Defense when using ranged weapons.");
+        }
+    }
+
+    private Weapon GetWeapon()
+    {
+        if (owner is Player p)
+            return p.rightHandWeapon ?? p.leftHandWeapon;
+        return null;
+    }
+
+    public void OnBeforeDamage(Character source, Character target, ref int damage)
+    {
+        if (source != owner) return;
+        Weapon weapon = GetWeapon();
+        if (weapon != null && weapon.weaponType == WeaponType.Ranged_Weapon)
+        {
+            damage += damageBonus;
+        }
+    }
+
+    public void OnAfterDamage(Character source, Character target, int finalDamage) { }
+}

--- a/LlmGame/Assets/Script/Item/StabilizerGloves.cs
+++ b/LlmGame/Assets/Script/Item/StabilizerGloves.cs
@@ -1,0 +1,24 @@
+using UnityEngine;
+
+public class StabilizerGloves : MonoBehaviour, IPassiveItem, IDamageReaction
+{
+    private Character owner;
+    private const int damageBonus = 5;
+
+    public void ApplyEffect(Character character)
+    {
+        owner = character;
+    }
+
+    public void OnBeforeDamage(Character source, Character target, ref int damage)
+    {
+        if (source != owner) return;
+        Weapon weapon = owner.rightHandWeapon ?? owner.leftHandWeapon;
+        if (weapon != null && weapon.weaponType == WeaponType.Ranged_Weapon)
+        {
+            damage += damageBonus;
+        }
+    }
+
+    public void OnAfterDamage(Character source, Character target, int finalDamage) { }
+}


### PR DESCRIPTION
## Summary
- add Hawk-Eye Lens, Combat HUD Processor, Ghostscope Overlay, Recoil Stabilizer and Stabilizer Gloves armor scripts
- allow Ghostscope Overlay to bypass armor feasibility/potential penalties for ranged weapons

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68947366d21083228a93085e324bd1b9