### PR TITLE
Add weapon-based status effect chances to possibility pool

### DIFF
--- a/LlmGame/Assets/Script/CharacterCombatHandler.cs
+++ b/LlmGame/Assets/Script/CharacterCombatHandler.cs
@@ -371,6 +371,9 @@ public class CharacterCombatHandler : MonoBehaviour
     {
         List<string> appliedEffects = new();
 
+        // 🔄 Refresh base chances from the attacker's active weapon(s)
+        ApplyWeaponStatusChances(attacker);
+
         // 🧠 Check if any passive guarantees crit (like BloodRushCore)
         bool forceCrit = false;
 
@@ -441,6 +444,36 @@ public class CharacterCombatHandler : MonoBehaviour
         {
             return " No special effects.";
         }
+    }
+
+    /// <summary>
+    /// Updates the attacker's possibility pool using status effect chances
+    /// provided by any active weapons. Multiple weapons stack additively and
+    /// values are clamped between 0 and 1 by the pool itself.
+    /// </summary>
+    /// <param name="attacker">Character performing the attack.</param>
+    private void ApplyWeaponStatusChances(Character attacker)
+    {
+        float bleed = 0f;
+        float poison = 0f;
+        float stun = 0f;
+        float crit = 0f;
+
+        foreach (var item in attacker.activeItem)
+        {
+            if (item is Weapon w)
+            {
+                bleed += w.bleedChance;
+                poison += w.poisonChance;
+                stun += w.stunChance;
+                crit += w.criticalChance;
+            }
+        }
+
+        attacker.possibilityPool.SetBaseChance(StatusChanceType.Bleed, bleed);
+        attacker.possibilityPool.SetBaseChance(StatusChanceType.Poison, poison);
+        attacker.possibilityPool.SetBaseChance(StatusChanceType.Stun, stun);
+        attacker.possibilityPool.SetBaseChance(StatusChanceType.Critical, crit);
     }
 
     public void SaveLastDamageBreakdown(Character attacker, Dictionary<DamageType, float> breakdown)

--- a/LlmGame/Assets/Script/Weapon.cs
+++ b/LlmGame/Assets/Script/Weapon.cs
@@ -28,4 +28,10 @@ public class Weapon : Item
     [Header("Weak Point")]
     public WeakPointData weakPointType;
 
+    [Header("Status Effect Chances")]
+    [Range(0f, 1f)] public float bleedChance;
+    [Range(0f, 1f)] public float poisonChance;
+    [Range(0f, 1f)] public float stunChance;
+    [Range(0f, 1f)] public float criticalChance;
+
 }

--- a/LlmGame/Assets/Script/enum.cs
+++ b/LlmGame/Assets/Script/enum.cs
@@ -88,7 +88,6 @@ public enum StatusChanceType
 {
     Bleed,
     Poison,
-    Burn,
     Stun,
     Critical
 }


### PR DESCRIPTION
## Summary
- allow weapons to contribute bleed, poison, stun, and crit chances to the possibility pool
- track weapon status chances before rolling status effects
- remove unused burn status type from possibility pool and enum

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68959a2cf7648322ba6e606d5201908b