### PR TITLE
Implement consumable combat items and MP regen

### DIFF
--- a/LlmGame/Assets/Script/Character.cs
+++ b/LlmGame/Assets/Script/Character.cs
@@ -55,6 +55,7 @@ public class Character : MonoBehaviour
     [SerializeField] public int currentHP;
     [SerializeField] public int currentMP;
     [SerializeField] public int currentshield;
+    public int mpRegenPerTurn;
     public List<MonoBehaviour> runtimePassiveBehaviors = new();
     public float turnGauge = 0f;
 
@@ -263,7 +264,10 @@ public class Character : MonoBehaviour
         if (existing != null)
         {
             existing.remainingTurns = Mathf.Max(existing.remainingTurns, newEffect.remainingTurns);
-            existing.magnitude = Mathf.Min(existing.magnitude + newEffect.magnitude, 3);
+            if (newEffect.effectType == StatusEffectType.CritChanceUp)
+                existing.magnitude += newEffect.magnitude;
+            else
+                existing.magnitude = Mathf.Min(existing.magnitude + newEffect.magnitude, 3);
         }
         else
         {
@@ -286,6 +290,14 @@ public class Character : MonoBehaviour
 
     public virtual void ProcessStatusEffects()
     {
+        if (mpRegenPerTurn > 0)
+        {
+            int before = currentMP;
+            currentMP = Mathf.Min(maxMP, currentMP + mpRegenPerTurn);
+            int gained = currentMP - before;
+            if (gained > 0)
+                Debug.Log($"{characterName} regenerates {gained} MP.");
+        }
 
         for (int i = activeStatusEffects.Count - 1; i >= 0; i--)
         {
@@ -350,6 +362,14 @@ public class Character : MonoBehaviour
                         speed += effect.magnitude;
                         effect.isApplied = true;
                         Debug.Log($"{characterName}'s speed is increased by {effect.magnitude}.");
+                    }
+                    break;
+                case StatusEffectType.CritChanceUp:
+                    if (!effect.isApplied)
+                    {
+                        possibilityPool.AddModifier(StatusChanceType.Critical, effect.magnitude / 100f);
+                        effect.isApplied = true;
+                        Debug.Log($"{characterName}'s critical chance is increased by {effect.magnitude}%.");
                     }
                     break;
 
@@ -457,6 +477,9 @@ public class Character : MonoBehaviour
                         break;
                     case StatusEffectType.SpeedUp:
                         speed -= effect.magnitude;
+                        break;
+                    case StatusEffectType.CritChanceUp:
+                        possibilityPool.AddModifier(StatusChanceType.Critical, -effect.magnitude / 100f);
                         break;
                 }
 

--- a/LlmGame/Assets/Script/ConsumeTurnItem.cs
+++ b/LlmGame/Assets/Script/ConsumeTurnItem.cs
@@ -9,6 +9,99 @@ public class ConsumeTurnItem : Item
 
     public virtual IEnumerator UseOnTarget(Character user, Character target, BattleManager battleManager)
     {
-        yield return null; // base does nothing
+        if (user == null || target == null || battleManager == null)
+        {
+            Debug.LogError("[ConsumeTurnItem] Null reference: user, target, or battleManager is null.");
+            yield break;
+        }
+
+        Debug.Log($"{user.characterName} uses {itemName} on {target.characterName}");
+
+        if (!string.IsNullOrEmpty(animationTrigger))
+        {
+            yield return battleManager.StartCoroutine(battleManager.WaitForAnimation(user, animationTrigger));
+        }
+        else
+        {
+            yield return new WaitForSeconds(0.25f);
+        }
+
+        switch (itemName)
+        {
+            case "Reinforced Plating":
+                target.defense += 10;
+                battleManager.battleLog.Add($"{user.characterName} used {itemName} on {target.characterName}, increasing defense by 10.");
+                break;
+
+            case "HP Booster":
+                target.maxHP = Mathf.RoundToInt(target.maxHP * 1.2f);
+                target.currentHP = Mathf.RoundToInt(target.currentHP * 1.2f);
+                if (target.currentHP > target.maxHP) target.currentHP = target.maxHP;
+                battleManager.battleLog.Add($"{user.characterName} boosted {target.characterName}'s HP by 20%.");
+                break;
+
+            case "MP Cell":
+                target.maxMP = Mathf.RoundToInt(target.maxMP * 1.2f);
+                target.currentMP = Mathf.RoundToInt(target.currentMP * 1.2f);
+                if (target.currentMP > target.maxMP) target.currentMP = target.maxMP;
+                battleManager.battleLog.Add($"{user.characterName} boosted {target.characterName}'s MP by 20%.");
+                break;
+
+            case "Bandage":
+                target.activeStatusEffects.RemoveAll(e => e.effectType == StatusEffectType.Bleed);
+                battleManager.battleLog.Add($"{user.characterName} bandaged {target.characterName}, removing bleeding.");
+                break;
+
+            case "Antidote":
+                target.activeStatusEffects.RemoveAll(e => e.effectType == StatusEffectType.Poison);
+                battleManager.battleLog.Add($"{user.characterName} cured {target.characterName}'s poison.");
+                break;
+
+            case "Shield Battery":
+                target.currentshield = Mathf.Min(target.maxShield, target.currentshield + 20);
+                battleManager.battleLog.Add($"{user.characterName} restored 20 shield to {target.characterName}.");
+                break;
+
+            case "Focus Tonic":
+                target.ApplyStatusEffect(new TurnStatusEffect(StatusEffectType.CritChanceUp, 2, 25));
+                battleManager.battleLog.Add($"{user.characterName} increased {target.characterName}'s critical chance.");
+                break;
+
+            case "Adrenaline Shot":
+                int heal25 = Mathf.RoundToInt(target.maxHP * 0.25f);
+                target.currentHP = Mathf.Min(target.maxHP, target.currentHP + heal25);
+                battleManager.battleLog.Add($"{user.characterName} healed {target.characterName} for {heal25} HP.");
+                break;
+
+            case "Soul Patch":
+                int heal50 = Mathf.RoundToInt(target.maxHP * 0.5f);
+                target.currentHP = Mathf.Min(target.maxHP, target.currentHP + heal50);
+                battleManager.battleLog.Add($"{user.characterName} healed {target.characterName} for {heal50} HP.");
+                break;
+
+            case "Overdrive Chip":
+                target.mpRegenPerTurn += 10;
+                battleManager.battleLog.Add($"{user.characterName} enhanced {target.characterName}'s MP regeneration by 10 per turn.");
+                break;
+
+            default:
+                Debug.LogWarning($"[ConsumeTurnItem] No effect implemented for {itemName}.");
+                break;
+        }
+
+        remain = Mathf.Max(0, remain - 1);
+
+        user.activeItem.Clear();
+        user.isUsingConsumeTurnItem = false;
+        battleManager.isUsingConsumableMode = false;
+
+        if (battleManager.playerInputField != null)
+        {
+            battleManager.playerInputField.text = "";
+            battleManager.playerInputField.interactable = true;
+        }
+
+        battleManager.chatAI.ShowInputUI();
+        battleManager.EndPlayerTurn();
     }
 }

--- a/LlmGame/Assets/Script/enum.cs
+++ b/LlmGame/Assets/Script/enum.cs
@@ -81,6 +81,7 @@ public enum StatusEffectType
     AttackUp,
     DefenseUp,
     SpeedUp,
+    CritChanceUp,
     HealReduction // ✅ Let compiler assign next value
 }
 


### PR DESCRIPTION
## Summary
- add CritChanceUp status effect and MP regen per turn support
- implement various consume-turn item effects such as Reinforced Plating, HP Booster, Focus Tonic, and more

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895a2e5391c8322983532d44c4ad2ef