### PR TITLE
Add rarity and value properties to items

### DIFF
--- a/LlmGame/Assets/Script/ArmorData.cs
+++ b/LlmGame/Assets/Script/ArmorData.cs
@@ -8,6 +8,8 @@ public class ArmorData : ScriptableObject
     public string armorName;
     [TextArea]
     public string description;
+    public ItemRarity rarity;
+    public int value;
 
     [Header("Slot Compatibility")]
     public List<BodyPartType> compatibleBodyParts; // ✅ NEW FIELD

--- a/LlmGame/Assets/Script/Item.cs
+++ b/LlmGame/Assets/Script/Item.cs
@@ -11,6 +11,8 @@ public class Item : ScriptableObject
     [TextArea]
     public string itemDescription;
     public ItemType itemType;
+    public ItemRarity rarity;
+    public int value;
 
     [Header("Usage")]
     public UsageType usageType;

--- a/LlmGame/Assets/Script/enum.cs
+++ b/LlmGame/Assets/Script/enum.cs
@@ -7,6 +7,13 @@ public enum ItemType
     Other
 }
 
+public enum ItemRarity
+{
+    Common,
+    Rare,
+    Epic
+}
+
 public enum WeaponType
 {
     Melee_Weapon,


### PR DESCRIPTION
## Summary
- add `ItemRarity` enum with Common, Rare, and Epic tiers
- track each item's rarity and value cost

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895a5f8a89c832298de8518659719f4