### PR TITLE
Add permanent status effects and new damage modifier skills

### DIFF
--- a/LlmGame/Assets/Script/Character.cs
+++ b/LlmGame/Assets/Script/Character.cs
@@ -263,18 +263,20 @@ public class Character : MonoBehaviour
         var existing = activeStatusEffects.Find(e => e.effectType == newEffect.effectType);
         if (existing != null)
         {
-            existing.remainingTurns = Mathf.Max(existing.remainingTurns, newEffect.remainingTurns);
-            if (newEffect.effectType == StatusEffectType.CritChanceUp)
+            existing.remainingTurns = existing.isPermanent ? int.MaxValue : Mathf.Max(existing.remainingTurns, newEffect.remainingTurns);
+            if (newEffect.effectType == StatusEffectType.CritChanceUp || newEffect.effectType == StatusEffectType.CritDamageUp)
                 existing.magnitude += newEffect.magnitude;
             else
                 existing.magnitude = Mathf.Min(existing.magnitude + newEffect.magnitude, 3);
+            existing.isPermanent = existing.isPermanent || newEffect.isPermanent;
         }
         else
         {
             activeStatusEffects.Add(newEffect);
         }
 
-        Debug.Log($"{characterName} gains {newEffect.effectType} for {newEffect.remainingTurns} turns.");
+        string durationText = newEffect.isPermanent ? "permanently" : $"{newEffect.remainingTurns} turns";
+        Debug.Log($"{characterName} gains {newEffect.effectType} for {durationText}.");
         // Check for contamination
         var poison = activeStatusEffects.Find(e => e.effectType == StatusEffectType.Poison);
         var radiation = activeStatusEffects.Find(e => e.effectType == StatusEffectType.Radiation);
@@ -372,6 +374,14 @@ public class Character : MonoBehaviour
                         Debug.Log($"{characterName}'s critical chance is increased by {effect.magnitude}%.");
                     }
                     break;
+                case StatusEffectType.CritDamageUp:
+                    if (!effect.isApplied)
+                    {
+                        possibilityPool.AddCriticalMultiplierBonus(effect.magnitude / 100f);
+                        effect.isApplied = true;
+                        Debug.Log($"{characterName}'s critical damage is increased by {effect.magnitude}%.");
+                    }
+                    break;
 
                 // 🧪 Damage-over-time effects
                 case StatusEffectType.Radiation:
@@ -450,10 +460,11 @@ public class Character : MonoBehaviour
             }
 
             // ⏳ Countdown
-            effect.remainingTurns--;
+            if (!effect.isPermanent)
+                effect.remainingTurns--;
 
             // 🧹 Expire effect
-            if (effect.remainingTurns <= 0)
+            if (!effect.isPermanent && effect.remainingTurns <= 0)
             {
                 switch (effect.effectType)
                 {
@@ -480,6 +491,9 @@ public class Character : MonoBehaviour
                         break;
                     case StatusEffectType.CritChanceUp:
                         possibilityPool.AddModifier(StatusChanceType.Critical, -effect.magnitude / 100f);
+                        break;
+                    case StatusEffectType.CritDamageUp:
+                        possibilityPool.AddCriticalMultiplierBonus(-effect.magnitude / 100f);
                         break;
                 }
 
@@ -579,7 +593,7 @@ public class Character : MonoBehaviour
 
     public bool HasStatusEffect(StatusEffectType type)
     {
-        return activeStatusEffects.Exists(effect => effect.effectType == type && effect.remainingTurns > 0);
+        return activeStatusEffects.Exists(effect => effect.effectType == type && (effect.isPermanent || effect.remainingTurns > 0));
     }
 
     #region  Equipment

--- a/LlmGame/Assets/Script/ConsumeTurnItem.cs
+++ b/LlmGame/Assets/Script/ConsumeTurnItem.cs
@@ -48,12 +48,12 @@ public class ConsumeTurnItem : Item
                 break;
 
             case "Bandage":
-                target.activeStatusEffects.RemoveAll(e => e.effectType == StatusEffectType.Bleed);
+                target.activeStatusEffects.RemoveAll(e => e.effectType == StatusEffectType.Bleed && !e.isPermanent);
                 battleManager.battleLog.Add($"{user.characterName} bandaged {target.characterName}, removing bleeding.");
                 break;
 
             case "Antidote":
-                target.activeStatusEffects.RemoveAll(e => e.effectType == StatusEffectType.Poison);
+                target.activeStatusEffects.RemoveAll(e => e.effectType == StatusEffectType.Poison && !e.isPermanent);
                 battleManager.battleLog.Add($"{user.characterName} cured {target.characterName}'s poison.");
                 break;
 

--- a/LlmGame/Assets/Script/DamageModifierSkill.cs
+++ b/LlmGame/Assets/Script/DamageModifierSkill.cs
@@ -51,6 +51,24 @@ public class DamageModifierSkill : ScriptableObject
         user.currentMP -= mpCost;
         Debug.Log($"{user.characterName} uses {skillName} on {target.characterName}");
 
+        // Apply specific skill effects
+        if (skillName == "Radiant Collapse")
+        {
+            // Permanent Poison and Radiation on target
+            var poison = new TurnStatusEffect(StatusEffectType.Poison, int.MaxValue, 1, user, true);
+            target.ApplyStatusEffect(poison);
+            var radiation = new TurnStatusEffect(StatusEffectType.Radiation, int.MaxValue, 1, user, true);
+            target.ApplyStatusEffect(radiation);
+        }
+        else if (skillName == "Multi-Target Scan")
+        {
+            // Buff user: next 3 attacks have +100% crit chance and +100% crit damage
+            var critChance = new TurnStatusEffect(StatusEffectType.CritChanceUp, 3, 100, user);
+            user.ApplyStatusEffect(critChance);
+            var critDamage = new TurnStatusEffect(StatusEffectType.CritDamageUp, 3, 100, user);
+            user.ApplyStatusEffect(critDamage);
+        }
+
         /*
         // ✅ Optional damage logic (currently commented out)
         */

--- a/LlmGame/Assets/Script/TurnStatusEffect.cs
+++ b/LlmGame/Assets/Script/TurnStatusEffect.cs
@@ -13,12 +13,16 @@ public class TurnStatusEffect
 
     public bool isApplied = false;
 
-    public TurnStatusEffect(StatusEffectType type, int duration, int magnitude, Character source = null)
+    // Marks effects that should never expire or be removed
+    public bool isPermanent = false;
+
+    public TurnStatusEffect(StatusEffectType type, int duration, int magnitude, Character source = null, bool isPermanent = false)
     {
         this.effectType = type;
         this.remainingTurns = duration;
         this.magnitude = magnitude;
         this.source = source;
+        this.isPermanent = isPermanent;
     }
 }
 

--- a/LlmGame/Assets/Script/enum.cs
+++ b/LlmGame/Assets/Script/enum.cs
@@ -82,6 +82,7 @@ public enum StatusEffectType
     DefenseUp,
     SpeedUp,
     CritChanceUp,
+    CritDamageUp,
     HealReduction // ✅ Let compiler assign next value
 }
 


### PR DESCRIPTION
## Summary
- Support permanent status effects via an `isPermanent` flag
- Add CritDamageUp status and respect permanent statuses in effect processing
- Implement Radiant Collapse and Multi-Target Scan skills with corresponding status applications

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895c5e512348322a70a754d8da38321