### PR TITLE
Add player data persistence and map-driven battle setup

### DIFF
--- a/LlmGame/Assets/Script/BattleManager.cs
+++ b/LlmGame/Assets/Script/BattleManager.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Linq;
 using TMPro;
 using System.Text.RegularExpressions; // Make sure this is at the top
+using Map;
 
 public class BattleManager : MonoBehaviour
 {
@@ -15,6 +16,11 @@ public class BattleManager : MonoBehaviour
     [SerializeField] public CharacterCombatHandler combatHandler;
     [SerializeField] public DamageCalculator damageCalculator;
     [SerializeField] public TMP_InputField playerInputField;
+
+    [Header("Enemy Pools")]
+    public List<GameObject> minorEnemyPrefabs = new List<GameObject>();
+    public List<GameObject> eliteEnemyPrefabs = new List<GameObject>();
+    public List<GameObject> bossEnemyPrefabs = new List<GameObject>();
 
     [Header("Show Debug")]
     [SerializeField] public bool showDebug;
@@ -41,13 +47,49 @@ public class BattleManager : MonoBehaviour
     private void Start()
     {
         player.turnGauge = 0f;
+        allCharacters.Clear();
         allCharacters.Add(player);
 
-        foreach (var e in enemies)
+        SpawnEnemyForCurrentNode();
+    }
+
+    private void SpawnEnemyForCurrentNode()
+    {
+        enemies.Clear();
+        if (PlayerData.Instance == null) return;
+
+        GameObject prefab = GetRandomEnemyPrefab(PlayerData.Instance.nextNodeType);
+        if (prefab == null) return;
+
+        GameObject enemyObj = Instantiate(prefab);
+        Enemy enemy = enemyObj.GetComponent<Enemy>();
+        if (enemy != null)
         {
-            e.turnGauge = 0f;
-            allCharacters.Add(e);
+            enemy.turnGauge = 0f;
+            enemies.Add(enemy);
+            allCharacters.Add(enemy);
         }
+    }
+
+    private GameObject GetRandomEnemyPrefab(NodeType type)
+    {
+        List<GameObject> pool = null;
+        switch (type)
+        {
+            case NodeType.MinorEnemy:
+                pool = minorEnemyPrefabs;
+                break;
+            case NodeType.EliteEnemy:
+                pool = eliteEnemyPrefabs;
+                break;
+            case NodeType.Boss:
+                pool = bossEnemyPrefabs;
+                break;
+        }
+
+        if (pool == null || pool.Count == 0) return null;
+        int index = Random.Range(0, pool.Count);
+        return pool[index];
     }
 
     private void Update()

--- a/LlmGame/Assets/Script/MapGenerate/MapPlayerTracker.cs
+++ b/LlmGame/Assets/Script/MapGenerate/MapPlayerTracker.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.Linq;
 using DG.Tweening;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace Map
 {
@@ -25,11 +26,8 @@ namespace Map
         {
             if (Locked) return;
 
-            // Debug.Log("Selected node: " + mapNode.Node.point);
-
             if (mapManager.CurrentMap.path.Count == 0)
             {
-                // player has not selected the node yet, he can select any of the nodes with y = 0
                 if (mapNode.Node.point.y == 0)
                     SendPlayerToNode(mapNode);
                 else
@@ -61,29 +59,36 @@ namespace Map
 
         private static void EnterNode(MapNode mapNode)
         {
-            // we have access to blueprint name here as well
             Debug.Log("Entering node: " + mapNode.Node.blueprintName + " of type: " + mapNode.Node.nodeType);
-            // load appropriate scene with context based on nodeType:
-            // or show appropriate GUI over the map: 
-            // if you choose to show GUI in some of these cases, do not forget to set "Locked" in MapPlayerTracker back to false
+            if (PlayerData.Instance != null)
+            {
+                PlayerData.Instance.SetNextNode(mapNode.Node.nodeType);
+            }
+
+            string sceneToLoad = string.Empty;
+
             switch (mapNode.Node.nodeType)
             {
                 case NodeType.MinorEnemy:
-                    break;
                 case NodeType.EliteEnemy:
+                case NodeType.Boss:
+                    sceneToLoad = "BattleScene";
                     break;
                 case NodeType.RestSite:
-                    break;
                 case NodeType.Treasure:
+                case NodeType.Mystery:
+                    sceneToLoad = "EventScene";
                     break;
                 case NodeType.Store:
-                    break;
-                case NodeType.Boss:
-                    break;
-                case NodeType.Mystery:
+                    sceneToLoad = "StoreScene";
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
+            }
+
+            if (!string.IsNullOrEmpty(sceneToLoad))
+            {
+                SceneManager.LoadScene(sceneToLoad);
             }
         }
 

--- a/LlmGame/Assets/Script/Player.cs
+++ b/LlmGame/Assets/Script/Player.cs
@@ -4,12 +4,29 @@ using UnityEngine;
 
 public class Player : Character
 {
+    public override void Awake()
+    {
+        base.Awake();
+        if (PlayerData.Instance != null)
+        {
+            PlayerData.Instance.LoadPlayer(this);
+        }
+    }
+
     void Start()
     {
         EquipAllPassives();
         Debug.Log(GetStatusChances());
         //this.ApplyStatusEffect(new TurnStatusEffect(StatusEffectType.Stun, 2, 0));
         //this.ApplyStatusEffect(new TurnStatusEffect(StatusEffectType.Bleed, 2, 1));
+    }
+
+    private void OnDestroy()
+    {
+        if (PlayerData.Instance != null)
+        {
+            PlayerData.Instance.SavePlayer(this);
+        }
     }
 
 }

--- a/LlmGame/Assets/Script/PlayerData.cs
+++ b/LlmGame/Assets/Script/PlayerData.cs
@@ -1,0 +1,95 @@
+using System.Collections.Generic;
+using UnityEngine;
+using Map;
+
+public class PlayerData : MonoBehaviour
+{
+    public static PlayerData Instance;
+
+    public NodeType nextNodeType;
+
+    // Basic stats
+    public int attack;
+    public int defense;
+    public int focus;
+    public int maxHP;
+    public int maxMP;
+    public int speed;
+    public int maxShield;
+    public int currentHP;
+    public int currentMP;
+    public int currentShield;
+    public int money;
+
+    // Inventory and equipment
+    public List<Item> inventoryItems = new List<Item>();
+    public Weapon leftHandWeapon;
+    public Weapon rightHandWeapon;
+    public List<PassiveItemData> equippedPassiveItems = new List<PassiveItemData>();
+
+    private bool initialized = false;
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+    }
+
+    public void SavePlayer(Player player)
+    {
+        attack = player.attack;
+        defense = player.defense;
+        focus = player.focus;
+        maxHP = player.maxHP;
+        maxMP = player.maxMP;
+        speed = player.speed;
+        maxShield = player.maxShield;
+        currentHP = player.currentHP;
+        currentMP = player.currentMP;
+        currentShield = player.currentshield;
+        money = player.money;
+
+        inventoryItems = new List<Item>(player.inventoryItems);
+        leftHandWeapon = player.leftHandWeapon;
+        rightHandWeapon = player.rightHandWeapon;
+        equippedPassiveItems = new List<PassiveItemData>(player.equippedPassiveItems);
+
+        initialized = true;
+    }
+
+    public void LoadPlayer(Player player)
+    {
+        if (!initialized)
+        {
+            SavePlayer(player);
+            return;
+        }
+
+        player.attack = attack;
+        player.defense = defense;
+        player.focus = focus;
+        player.maxHP = maxHP;
+        player.maxMP = maxMP;
+        player.speed = speed;
+        player.maxShield = maxShield;
+        player.currentHP = currentHP;
+        player.currentMP = currentMP;
+        player.currentshield = currentShield;
+        player.money = money;
+
+        player.inventoryItems = new List<Item>(inventoryItems);
+        player.leftHandWeapon = leftHandWeapon;
+        player.rightHandWeapon = rightHandWeapon;
+        player.equippedPassiveItems = new List<PassiveItemData>(equippedPassiveItems);
+    }
+
+    public void SetNextNode(NodeType type)
+    {
+        nextNodeType = type;
+    }
+}


### PR DESCRIPTION
## Summary
- preserve player stats and inventory across scenes via new `PlayerData` singleton
- route map node selections to proper scenes and store upcoming node type
- spawn enemies based on node difficulty in `BattleManager`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896e41c9398832295ee259a97c8b74a