### PR TITLE
Add enemy difficulty presets and scene transitions

### DIFF
--- a/LlmGame/Assets/Script/BattleManager.cs
+++ b/LlmGame/Assets/Script/BattleManager.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using TMPro;
 using System.Text.RegularExpressions; // Make sure this is at the top
 using Map;
+using UnityEngine.SceneManagement;
 
 public class BattleManager : MonoBehaviour
 {
@@ -18,8 +19,11 @@ public class BattleManager : MonoBehaviour
     [SerializeField] public TMP_InputField playerInputField;
 
     [Header("Enemy Pools")]
-    public List<GameObject> minorEnemyPrefabs = new List<GameObject>();
-    public List<GameObject> eliteEnemyPrefabs = new List<GameObject>();
+    public List<GameObject> minorEasyPrefabs = new List<GameObject>();
+    public List<GameObject> minorNormalPrefabs = new List<GameObject>();
+    public List<GameObject> minorHardPrefabs = new List<GameObject>();
+    public List<GameObject> eliteEasyPrefabs = new List<GameObject>();
+    public List<GameObject> eliteHardPrefabs = new List<GameObject>();
     public List<GameObject> bossEnemyPrefabs = new List<GameObject>();
 
     [Header("Show Debug")]
@@ -58,7 +62,7 @@ public class BattleManager : MonoBehaviour
         enemies.Clear();
         if (PlayerData.Instance == null) return;
 
-        GameObject prefab = GetRandomEnemyPrefab(PlayerData.Instance.nextNodeType);
+        GameObject prefab = GetRandomEnemyPrefab(PlayerData.Instance.nextNodeType, PlayerData.Instance.nextEnemyDifficulty);
         if (prefab == null) return;
 
         GameObject enemyObj = Instantiate(prefab);
@@ -71,16 +75,22 @@ public class BattleManager : MonoBehaviour
         }
     }
 
-    private GameObject GetRandomEnemyPrefab(NodeType type)
+    private GameObject GetRandomEnemyPrefab(NodeType type, EnemyDifficulty difficulty)
     {
         List<GameObject> pool = null;
         switch (type)
         {
             case NodeType.MinorEnemy:
-                pool = minorEnemyPrefabs;
+                pool = difficulty switch
+                {
+                    EnemyDifficulty.Easy => minorEasyPrefabs,
+                    EnemyDifficulty.Normal => minorNormalPrefabs,
+                    EnemyDifficulty.Hard => minorHardPrefabs,
+                    _ => minorEasyPrefabs
+                };
                 break;
             case NodeType.EliteEnemy:
-                pool = eliteEnemyPrefabs;
+                pool = difficulty == EnemyDifficulty.Easy ? eliteEasyPrefabs : eliteHardPrefabs;
                 break;
             case NodeType.Boss:
                 pool = bossEnemyPrefabs;
@@ -374,6 +384,7 @@ public class BattleManager : MonoBehaviour
         if (!player.IsAlive())
         {
             Debug.Log("Player Defeated!");
+            SceneManager.LoadScene("GameOver");
             return true;
         }
 
@@ -381,6 +392,7 @@ public class BattleManager : MonoBehaviour
         if (!anyEnemyAlive)
         {
             Debug.Log("All Enemies Defeated!");
+            SceneManager.LoadScene("MapGenerate");
         }
 
         return !anyEnemyAlive;

--- a/LlmGame/Assets/Script/MapGenerate/MapConfig.cs
+++ b/LlmGame/Assets/Script/MapGenerate/MapConfig.cs
@@ -20,6 +20,14 @@ namespace Map
 
         [Tooltip("Increase this number to generate more paths")]
         public int extraPaths;
+
+        [Header("Enemy Difficulty Distribution")]
+        [Range(0,100)] public int minorEasyPercent = 30;
+        [Range(0,100)] public int minorNormalPercent = 30;
+        [Range(0,100)] public int minorHardPercent = 40;
+        [Range(0,100)] public int eliteEasyPercent = 50;
+        [Range(0,100)] public int eliteHardPercent = 50;
+
         public List<MapLayer> layers;
     }
 }

--- a/LlmGame/Assets/Script/MapGenerate/MapGenerator.cs
+++ b/LlmGame/Assets/Script/MapGenerate/MapGenerator.cs
@@ -74,7 +74,26 @@ namespace Map
                     ? supportedRandomNodeTypes.Random()
                     : layer.nodeType;
                 string blueprintName = config.nodeBlueprints.Where(b => b.nodeType == nodeType).ToList().Random().name;
-                Node node = new Node(nodeType, blueprintName, new Vector2Int(i, layerIndex))
+
+                EnemyDifficulty difficulty = EnemyDifficulty.Easy;
+                float layerPercent = (layerIndex / (float)config.layers.Count) * 100f;
+                if (nodeType == NodeType.MinorEnemy)
+                {
+                    if (layerPercent < config.minorEasyPercent)
+                        difficulty = EnemyDifficulty.Easy;
+                    else if (layerPercent < config.minorEasyPercent + config.minorNormalPercent)
+                        difficulty = EnemyDifficulty.Normal;
+                    else
+                        difficulty = EnemyDifficulty.Hard;
+                }
+                else if (nodeType == NodeType.EliteEnemy)
+                {
+                    difficulty = layerPercent < config.eliteEasyPercent
+                        ? EnemyDifficulty.Easy
+                        : EnemyDifficulty.Hard;
+                }
+
+                Node node = new Node(nodeType, blueprintName, new Vector2Int(i, layerIndex), difficulty)
                 {
                     position = new Vector2(-offset + i * layer.nodesApartDistance, GetDistanceToLayer(layerIndex))
                 };

--- a/LlmGame/Assets/Script/MapGenerate/MapPlayerTracker.cs
+++ b/LlmGame/Assets/Script/MapGenerate/MapPlayerTracker.cs
@@ -62,7 +62,7 @@ namespace Map
             Debug.Log("Entering node: " + mapNode.Node.blueprintName + " of type: " + mapNode.Node.nodeType);
             if (PlayerData.Instance != null)
             {
-                PlayerData.Instance.SetNextNode(mapNode.Node.nodeType);
+                PlayerData.Instance.SetNextNode(mapNode.Node.nodeType, mapNode.Node.enemyDifficulty);
             }
 
             string sceneToLoad = string.Empty;

--- a/LlmGame/Assets/Script/MapGenerate/Node.cs
+++ b/LlmGame/Assets/Script/MapGenerate/Node.cs
@@ -13,14 +13,17 @@ namespace Map
         public readonly List<Vector2Int> outgoing = new List<Vector2Int>();
         [JsonConverter(typeof(StringEnumConverter))]
         public readonly NodeType nodeType;
+        [JsonConverter(typeof(StringEnumConverter))]
+        public readonly EnemyDifficulty enemyDifficulty;
         public readonly string blueprintName;
         public Vector2 position;
 
-        public Node(NodeType nodeType, string blueprintName, Vector2Int point)
+        public Node(NodeType nodeType, string blueprintName, Vector2Int point, EnemyDifficulty difficulty)
         {
             this.nodeType = nodeType;
             this.blueprintName = blueprintName;
             this.point = point;
+            this.enemyDifficulty = difficulty;
         }
 
         public void AddIncoming(Vector2Int p)

--- a/LlmGame/Assets/Script/PlayerData.cs
+++ b/LlmGame/Assets/Script/PlayerData.cs
@@ -7,6 +7,7 @@ public class PlayerData : MonoBehaviour
     public static PlayerData Instance;
 
     public NodeType nextNodeType;
+    public EnemyDifficulty nextEnemyDifficulty;
 
     // Basic stats
     public int attack;
@@ -153,8 +154,9 @@ public class PlayerData : MonoBehaviour
         }
     }
 
-    public void SetNextNode(NodeType type)
+    public void SetNextNode(NodeType type, EnemyDifficulty difficulty)
     {
         nextNodeType = type;
+        nextEnemyDifficulty = difficulty;
     }
 }

--- a/LlmGame/Assets/Script/enum.cs
+++ b/LlmGame/Assets/Script/enum.cs
@@ -100,3 +100,10 @@ public enum StatusChanceType
     Stun,
     Critical
 }
+
+public enum EnemyDifficulty
+{
+    Easy,
+    Normal,
+    Hard
+}


### PR DESCRIPTION
## Summary
- Add `EnemyDifficulty` enum and apply to map nodes
- Generate map nodes with difficulty tiers based on layer percentages
- Spawn enemies and load scenes according to enemy difficulty and battle outcome

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6896fae6d2e483229ebb5cb1924a7e69