### PR TITLE
Implement store, treasure and mystery systems

### DIFF
--- a/LlmGame/Assets/Script/MapGenerate/MapPlayerTracker.cs
+++ b/LlmGame/Assets/Script/MapGenerate/MapPlayerTracker.cs
@@ -75,9 +75,13 @@ namespace Map
                     sceneToLoad = "BattleScene";
                     break;
                 case NodeType.RestSite:
+                    sceneToLoad = "RestScene";
+                    break;
                 case NodeType.Treasure:
+                    sceneToLoad = "TreasureScene";
+                    break;
                 case NodeType.Mystery:
-                    sceneToLoad = "EventScene";
+                    sceneToLoad = "MysteryScene";
                     break;
                 case NodeType.Store:
                     sceneToLoad = "StoreScene";

--- a/LlmGame/Assets/Script/MysteryEventSystem.cs
+++ b/LlmGame/Assets/Script/MysteryEventSystem.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Chooses a random event prefab and spawns it when the scene loads.
+/// </summary>
+public class MysteryEventSystem : MonoBehaviour
+{
+    public List<GameObject> eventPrefabs = new();
+
+    private void Start()
+    {
+        if (eventPrefabs.Count == 0) return;
+        int index = Random.Range(0, eventPrefabs.Count);
+        Instantiate(eventPrefabs[index], transform);
+    }
+}

--- a/LlmGame/Assets/Script/StoreSystem.cs
+++ b/LlmGame/Assets/Script/StoreSystem.cs
@@ -1,0 +1,102 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+/// <summary>
+/// Generates a list of items for the store. Ensures no duplicates with player's inventory.
+/// Supports passive items and armor. Selection weighted by item rarity.
+/// </summary>
+public class StoreSystem : MonoBehaviour
+{
+    [Header("Item Pools")]
+    public List<PassiveItemData> passiveItems = new();
+    public List<ArmorData> armors = new();
+
+    [Header("Rarity Weights")]
+    [Range(0,100)] public int commonWeight = 60;
+    [Range(0,100)] public int rareWeight = 30;
+    [Range(0,100)] public int epicWeight = 10;
+
+    /// <summary>
+    /// Create a store stock list with items the player doesn't already own.
+    /// </summary>
+    public List<ScriptableObject> GenerateStock(Player player, int count)
+    {
+        var pool = BuildAvailablePool(player);
+        var stock = new List<ScriptableObject>();
+        for (int i = 0; i < count && pool.Count > 0; i++)
+        {
+            var item = GetRandomItem(pool);
+            stock.Add(item);
+            pool.Remove(item);
+        }
+        return stock;
+    }
+
+    /// <summary>
+    /// Attempt to purchase an item and add it to the player.
+    /// </summary>
+    public void BuyItem(Player player, ScriptableObject item)
+    {
+        if (item is PassiveItemData passive)
+        {
+            if (!player.equippedPassiveItems.Contains(passive))
+                player.equippedPassiveItems.Add(passive);
+        }
+        else if (item is ArmorData armor)
+        {
+            // Equip to first compatible body part without this armor
+            var part = player.bodyParts.FirstOrDefault(p => armor.compatibleBodyParts.Contains(p.type) && p.equippedArmor != armor);
+            if (part != null)
+            {
+                part.equippedArmor = armor;
+            }
+        }
+    }
+
+    private List<ScriptableObject> BuildAvailablePool(Player player)
+    {
+        var pool = new List<ScriptableObject>();
+        var ownedPassives = new HashSet<PassiveItemData>(player.equippedPassiveItems);
+        var ownedArmors = new HashSet<ArmorData>(player.bodyParts.Where(p => p.equippedArmor != null).Select(p => p.equippedArmor));
+
+        pool.AddRange(passiveItems.Where(p => !ownedPassives.Contains(p)));
+        pool.AddRange(armors.Where(a => !ownedArmors.Contains(a)));
+        return pool;
+    }
+
+    private ScriptableObject GetRandomItem(List<ScriptableObject> pool)
+    {
+        int total = pool.Sum(i => GetWeight(GetRarity(i)));
+        int roll = Random.Range(0, total);
+        foreach (var item in pool)
+        {
+            int w = GetWeight(GetRarity(item));
+            if (roll < w)
+                return item;
+            roll -= w;
+        }
+        return pool[0];
+    }
+
+    private ItemRarity GetRarity(ScriptableObject obj)
+    {
+        return obj switch
+        {
+            PassiveItemData p => p.rarity,
+            ArmorData a => a.rarity,
+            _ => ItemRarity.Common
+        };
+    }
+
+    private int GetWeight(ItemRarity rarity)
+    {
+        return rarity switch
+        {
+            ItemRarity.Common => commonWeight,
+            ItemRarity.Rare => rareWeight,
+            ItemRarity.Epic => epicWeight,
+            _ => commonWeight
+        };
+    }
+}

--- a/LlmGame/Assets/Script/TreasureSystem.cs
+++ b/LlmGame/Assets/Script/TreasureSystem.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Handles treasure rewards, granting the player a random item they don't already own.
+/// Uses the StoreSystem's pools for item selection.
+/// </summary>
+public class TreasureSystem : MonoBehaviour
+{
+    public StoreSystem storeReference;
+
+    /// <summary>
+    /// Grants a random item to the player.
+    /// </summary>
+    public ScriptableObject GrantTreasure(Player player)
+    {
+        if (storeReference == null)
+        {
+            Debug.LogWarning("TreasureSystem requires StoreSystem reference");
+            return null;
+        }
+
+        List<ScriptableObject> stock = storeReference.GenerateStock(player, 1);
+        if (stock.Count == 0) return null;
+
+        ScriptableObject item = stock[0];
+        storeReference.BuyItem(player, item);
+        return item;
+    }
+}


### PR DESCRIPTION
## Summary
- Load dedicated scenes for rest, treasure, and mystery nodes
- Add store system with weighted item selection excluding owned gear
- Add treasure and mystery event systems leveraging the store pools

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68971233b45c8322ac0a967ef23a94e8