### PR TITLE
Handle mystery encounter battles

### DIFF
--- a/LlmGame/Assets/Script/MysteryEventUI.cs
+++ b/LlmGame/Assets/Script/MysteryEventUI.cs
@@ -5,6 +5,7 @@ using TMPro;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
+using Map;
 
 public class MysteryEventUI : MonoBehaviour
 {
@@ -167,7 +168,17 @@ public class MysteryEventUI : MonoBehaviour
         // load next scene
         if (!string.IsNullOrEmpty(nextSceneName))
         {
-            SceneManager.LoadScene(nextSceneName);
+            var data = PlayerData.Instance;
+            if (data != null && (data.nextNodeType == NodeType.MinorEnemy ||
+                                 data.nextNodeType == NodeType.EliteEnemy ||
+                                 data.nextNodeType == NodeType.Boss))
+            {
+                SceneManager.LoadScene("BattleScene");
+            }
+            else
+            {
+                SceneManager.LoadScene(nextSceneName);
+            }
         }
     }
 

--- a/LlmGame/Assets/Script/MysterySceneEventHandler.cs
+++ b/LlmGame/Assets/Script/MysterySceneEventHandler.cs
@@ -102,7 +102,7 @@ public class MysterySceneEventHandler : MonoBehaviour
             return;
         }
         Weapon weapon = weaponPool[Random.Range(0, weaponPool.Count)];
-        player.leftHandWeapon = weapon; // simple assignment for now
+        player.inventoryItems.Add(weapon);
         Log($"Granted weapon: {weapon.name}");
     }
 


### PR DESCRIPTION
## Summary
- Drop mystery weapons into player inventory instead of auto-equipping
- Send player directly to battle scene when mystery events queue an encounter

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ac8e429a88322934c63352683fff9