### PR TITLE
Add DeApplyEffect for passive items and reset before saving

### DIFF
--- a/LlmGame/Assets/ObjCharacter/PassiveItem/BloodTuner/BloodTuner.cs
+++ b/LlmGame/Assets/ObjCharacter/PassiveItem/BloodTuner/BloodTuner.cs
@@ -6,6 +6,8 @@ public class BloodTuner : MonoBehaviour, IPassiveItem, IStatusEffectListener
 {
     public void ApplyEffect(Character character) { }
 
+    public void DeApplyEffect(Character character) { }
+
     public void OnAfterDamage(Character source, Character target, int finalDamage)
     {
         throw new System.NotImplementedException();

--- a/LlmGame/Assets/ObjCharacter/PassiveItem/ContagionCore/ContagionCore.cs
+++ b/LlmGame/Assets/ObjCharacter/PassiveItem/ContagionCore/ContagionCore.cs
@@ -6,6 +6,8 @@ public class ContagionCore : MonoBehaviour, IDeathListener, IPassiveItem
 {
     public void ApplyEffect(Character character) { }
 
+    public void DeApplyEffect(Character character) { }
+
     public void OnAfterDamage(Character source, Character target, int finalDamage)
     {
         throw new System.NotImplementedException();

--- a/LlmGame/Assets/Script/Item/AdaptiveSyncCore.cs
+++ b/LlmGame/Assets/Script/Item/AdaptiveSyncCore.cs
@@ -15,4 +15,16 @@ public class AdaptiveSyncCore : PassiveItemBase
         character.currentMP += 5;
         character.speed += 5;
     }
+
+    public override void DeApplyEffect(Character character)
+    {
+        character.attack -= 5;
+        character.defense -= 5;
+        character.focus -= 5;
+        character.maxHP -= 5;
+        character.currentHP = Mathf.Clamp(character.currentHP - 5, 0, character.maxHP);
+        character.maxMP -= 5;
+        character.currentMP = Mathf.Clamp(character.currentMP - 5, 0, character.maxMP);
+        character.speed -= 5;
+    }
 }

--- a/LlmGame/Assets/Script/Item/AdrenalSurge.cs
+++ b/LlmGame/Assets/Script/Item/AdrenalSurge.cs
@@ -15,6 +15,15 @@ public class AdrenalSurge : MonoBehaviour, IPassiveItem, IDamageReaction, ITurnL
         // Nothing to do immediately
     }
 
+    public void DeApplyEffect(Character character)
+    {
+        if (buffActive)
+        {
+            character.speed -= boostAmount;
+            buffActive = false;
+        }
+    }
+
     // 🔥 Trigger when character takes damage
     public void OnAfterDamage(Character source, Character target, int finalDamage)
     {

--- a/LlmGame/Assets/Script/Item/AutoInjectorArms.cs
+++ b/LlmGame/Assets/Script/Item/AutoInjectorArms.cs
@@ -17,6 +17,15 @@ public class AutoInjectorArms : MonoBehaviour, IPassiveItem, ITurnListener
         Debug.Log("💉 Auto-Injector Arms equipped: will inject buffs every 2 turns.");
     }
 
+    public void DeApplyEffect(Character character)
+    {
+        if (owner == character)
+        {
+            owner = null;
+            turnCounter = 0;
+        }
+    }
+
     public void OnTurnStart(Character character)
     {
         if (character != owner) return;

--- a/LlmGame/Assets/Script/Item/AutoRepairGel.cs
+++ b/LlmGame/Assets/Script/Item/AutoRepairGel.cs
@@ -12,6 +12,11 @@ public class AutoRepairGel : MonoBehaviour, IPassiveItem, ITurnListener
         // No immediate effect
     }
 
+    public void DeApplyEffect(Character character)
+    {
+        turnCounter = 0;
+    }
+
     public void OnTurnStart(Character character)
     {
         // Not needed

--- a/LlmGame/Assets/Script/Item/BioCapacitorImplant.cs
+++ b/LlmGame/Assets/Script/Item/BioCapacitorImplant.cs
@@ -9,4 +9,10 @@ public class BioCapacitorImplant : PassiveItemBase
         character.maxMP += 15;
         character.currentMP += 15;
     }
+
+    public override void DeApplyEffect(Character character)
+    {
+        character.maxMP -= 15;
+        character.currentMP = Mathf.Clamp(character.currentMP - 15, 0, character.maxMP);
+    }
 }

--- a/LlmGame/Assets/Script/Item/BiohazardReactor.cs
+++ b/LlmGame/Assets/Script/Item/BiohazardReactor.cs
@@ -12,6 +12,8 @@ public class BiohazardReactor : MonoBehaviour, IPassiveItem, IDamageReaction
         // No immediate effect
     }
 
+    public void DeApplyEffect(Character character) { }
+
     public void OnBeforeDamage(Character source, Character target, ref int damage)
     {
         if (source == null || target == null) return;

--- a/LlmGame/Assets/Script/Item/Bleeding-Increasing Coating.cs
+++ b/LlmGame/Assets/Script/Item/Bleeding-Increasing Coating.cs
@@ -12,6 +12,8 @@ public class BleedingIncreasingCoating : MonoBehaviour, IPassiveItem, IPossibili
         // Optional: for visual feedback or initial setup
     }
 
+    public void DeApplyEffect(Character character) { }
+
     public void ModifyChances(PossibilityPool pool)
     {
         pool.AddModifier(StatusChanceType.Bleed, bleedChanceBonus);

--- a/LlmGame/Assets/Script/Item/BloodRushCore.cs
+++ b/LlmGame/Assets/Script/Item/BloodRushCore.cs
@@ -15,6 +15,15 @@ public class BloodRushCore : MonoBehaviour, IPassiveItem, ITurnListener, IStatus
         Debug.Log("🩸 Blood Rush Core equipped.");
     }
 
+    public void DeApplyEffect(Character character)
+    {
+        if (owner == character)
+        {
+            owner = null;
+            ResetState();
+        }
+    }
+
     public void OnTurnStart(Character character)
     {
         if (character != owner) return;

--- a/LlmGame/Assets/Script/Item/CognitiveLoopEnhancer.cs
+++ b/LlmGame/Assets/Script/Item/CognitiveLoopEnhancer.cs
@@ -8,4 +8,9 @@ public class CognitiveLoopEnhancer : PassiveItemBase
     {
         character.focus += 5;
     }
+
+    public override void DeApplyEffect(Character character)
+    {
+        character.focus -= 5;
+    }
 }

--- a/LlmGame/Assets/Script/Item/CombatGrips.cs
+++ b/LlmGame/Assets/Script/Item/CombatGrips.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 public class CombatGrips : MonoBehaviour, IPassiveItem
 {
     private const float meleeDamageMultiplier = 0.10f;
+    private int bonusAttack = 0;
 
     public void ApplyEffect(Character character)
     {
@@ -13,14 +14,24 @@ public class CombatGrips : MonoBehaviour, IPassiveItem
 
         if (weapon != null && weapon.weaponType == WeaponType.Melee_Weapon)
         {
-            int bonusAttack = Mathf.RoundToInt(character.attack * meleeDamageMultiplier);
+            bonusAttack = Mathf.RoundToInt(character.attack * meleeDamageMultiplier);
             character.attack += bonusAttack;
 
             Debug.Log($"🥊 Combat Grips equipped: +{bonusAttack} Attack (+10%) for melee weapon.");
         }
         else
         {
+            bonusAttack = 0;
             Debug.Log("🥊 Combat Grips equipped, but no melee weapon detected.");
+        }
+    }
+
+    public void DeApplyEffect(Character character)
+    {
+        if (bonusAttack != 0)
+        {
+            character.attack -= bonusAttack;
+            bonusAttack = 0;
         }
     }
 

--- a/LlmGame/Assets/Script/Item/CombatHUDProcessor.cs
+++ b/LlmGame/Assets/Script/Item/CombatHUDProcessor.cs
@@ -12,6 +12,15 @@ public class CombatHUDProcessor : MonoBehaviour, IPassiveItem, ITurnListener, ID
         Debug.Log("📡 Combat HUD Processor equipped: first ranged attack each turn deals +20 explosive damage.");
     }
 
+    public void DeApplyEffect(Character character)
+    {
+        if (owner == character)
+        {
+            owner = null;
+            usedThisTurn = false;
+        }
+    }
+
     public void OnTurnStart(Character character)
     {
         if (character == owner)

--- a/LlmGame/Assets/Script/Item/CombatMemoryChip.cs
+++ b/LlmGame/Assets/Script/Item/CombatMemoryChip.cs
@@ -4,10 +4,17 @@ using UnityEngine;
 
 public class CombatMemoryChip : PassiveItemBase
 {
+    private int bonus = 0;
     public override void ApplyEffect(Character character)
     {
-        int bonus = (character.focus / 3) * 2;
+        bonus = (character.focus / 3) * 2;
         character.attack += bonus;
+    }
+
+    public override void DeApplyEffect(Character character)
+    {
+        character.attack -= bonus;
+        bonus = 0;
     }
 }
 

--- a/LlmGame/Assets/Script/Item/EmbeddedPainkiller.cs
+++ b/LlmGame/Assets/Script/Item/EmbeddedPainkiller.cs
@@ -14,6 +14,12 @@ public class EmbeddedPainkiller : MonoBehaviour, IPassiveItem, IDamageReaction
         character.currentHP += 15;
     }
 
+    public void DeApplyEffect(Character character)
+    {
+        character.maxHP -= 15;
+        character.currentHP = Mathf.Clamp(character.currentHP - 15, 0, character.maxHP);
+    }
+
     public void OnBeforeDamage(Character source, Character target, ref int damage)
     {
         float reduced = damage * (damageReductionPercent / 100f);

--- a/LlmGame/Assets/Script/Item/GhostscopeOverlay.cs
+++ b/LlmGame/Assets/Script/Item/GhostscopeOverlay.cs
@@ -7,6 +7,8 @@ public class GhostscopeOverlay : MonoBehaviour, IPassiveItem
         Debug.Log("👻 Ghostscope Overlay equipped: ranged attacks ignore feasibility and potential penalties from armor.");
     }
 
+    public void DeApplyEffect(Character character) { }
+
     public void OnAfterDamage(Character source, Character target, int finalDamage) { }
     public void OnBeforeDamage(Character source, Character target, ref int damage) { }
 }

--- a/LlmGame/Assets/Script/Item/GyroStabilizedFeet.cs
+++ b/LlmGame/Assets/Script/Item/GyroStabilizedFeet.cs
@@ -12,6 +12,8 @@ public class GyroStabilizedFeet : MonoBehaviour, IPassiveItem, IStatusEffectList
         Debug.Log("🌀 Gyro-Stabilized Feet equipped: Blocking " + string.Join(", ", blockedEffects));
     }
 
+    public void DeApplyEffect(Character character) { }
+
     public void OnAfterDamage(Character source, Character target, int finalDamage)
     {
         throw new System.NotImplementedException();

--- a/LlmGame/Assets/Script/Item/HawkEyeLens.cs
+++ b/LlmGame/Assets/Script/Item/HawkEyeLens.cs
@@ -17,6 +17,14 @@ public class HawkEyeLens : MonoBehaviour, IPassiveItem
         }
     }
 
+    public void DeApplyEffect(Character character)
+    {
+        if (character is Player player)
+        {
+            player.possibilityPool.AddModifier(StatusChanceType.Critical, -critBonus);
+        }
+    }
+
     public void OnAfterDamage(Character source, Character target, int finalDamage) { }
     public void OnBeforeDamage(Character source, Character target, ref int damage) { }
 }

--- a/LlmGame/Assets/Script/Item/HeadTargetingSystem.cs
+++ b/LlmGame/Assets/Script/Item/HeadTargetingSystem.cs
@@ -8,6 +8,8 @@ public class HeadTargetingSystem : MonoBehaviour, IPassiveItem, IHitModifier
 
     public void ApplyEffect(Character character) { }
 
+    public void DeApplyEffect(Character character) { }
+
     public void OnAfterDamage(Character source, Character target, int finalDamage)
     {
         throw new System.NotImplementedException();

--- a/LlmGame/Assets/Script/Item/HollowpointModulator.cs
+++ b/LlmGame/Assets/Script/Item/HollowpointModulator.cs
@@ -10,6 +10,8 @@ public class HollowpointModulator : PassiveItemBase, IDamageReaction
         // Could add visuals/sfx here if desired
     }
 
+    public override void DeApplyEffect(Character character) { }
+
     public new void OnBeforeDamage(Character source, Character target, ref int damage)
     {
         if (source == null || !(source is Character attacker)) return;

--- a/LlmGame/Assets/Script/Item/IPassiveItem.cs
+++ b/LlmGame/Assets/Script/Item/IPassiveItem.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 public interface IPassiveItem
 {
     void ApplyEffect(Character character);
+    void DeApplyEffect(Character character);
     public void OnAfterDamage(Character source, Character target, int finalDamage);
     public void OnBeforeDamage(Character source, Character target, ref int damage);
 }

--- a/LlmGame/Assets/Script/Item/InjectorGauntlets.cs
+++ b/LlmGame/Assets/Script/Item/InjectorGauntlets.cs
@@ -9,6 +9,8 @@ public class InjectorGauntlets : MonoBehaviour, IPassiveItem, IDamageReaction
         // No immediate effect
     }
 
+    public void DeApplyEffect(Character character) { }
+
     public void OnBeforeDamage(Character source, Character target, ref int damage) { }
 
     public void OnAfterDamage(Character source, Character target, int finalDamage)

--- a/LlmGame/Assets/Script/Item/IrradiationMatrix.cs
+++ b/LlmGame/Assets/Script/Item/IrradiationMatrix.cs
@@ -6,6 +6,8 @@ public class IrradiationMatrix : MonoBehaviour, IPassiveItem
 {
     public void ApplyEffect(Character character) { }
 
+    public void DeApplyEffect(Character character) { }
+
     public void OnAfterDamage(Character source, Character target, int finalDamage)
     {
         throw new System.NotImplementedException();

--- a/LlmGame/Assets/Script/Item/MSGNoodle.cs
+++ b/LlmGame/Assets/Script/Item/MSGNoodle.cs
@@ -9,4 +9,10 @@ public class MSGNoodle : PassiveItemBase
         character.maxHP += 10;
         character.currentHP += 10;
     }
+
+    public override void DeApplyEffect(Character character)
+    {
+        character.maxHP -= 10;
+        character.currentHP = Mathf.Clamp(character.currentHP - 10, 0, character.maxHP);
+    }
 }

--- a/LlmGame/Assets/Script/Item/NanoVascularMicrorobot.cs
+++ b/LlmGame/Assets/Script/Item/NanoVascularMicrorobot.cs
@@ -10,4 +10,10 @@ public class NanoVascularMicrorobot : PassiveItemBase
         character.maxHP += 25;
         character.currentHP += 25;
     }
+
+    public override void DeApplyEffect(Character character)
+    {
+        character.maxHP -= 25;
+        character.currentHP = Mathf.Clamp(character.currentHP - 25, 0, character.maxHP);
+    }
 }

--- a/LlmGame/Assets/Script/Item/NerveRotVials.cs
+++ b/LlmGame/Assets/Script/Item/NerveRotVials.cs
@@ -13,6 +13,8 @@ public class NerveRotVials : MonoBehaviour, IPassiveItem, IDamageReaction
         // Not needed at equip time
     }
 
+    public void DeApplyEffect(Character character) { }
+
     public void OnBeforeDamage(Character source, Character target, ref int damage)
     {
         // Not used

--- a/LlmGame/Assets/Script/Item/NervousSystemSeparator.cs
+++ b/LlmGame/Assets/Script/Item/NervousSystemSeparator.cs
@@ -5,14 +5,20 @@ using UnityEngine;
 
 public class NervousSystemSeparator : MonoBehaviour, IPassiveItem
 {
+    private int focusBoost;
+
     public void ApplyEffect(Character character)
     {
         BattleManager battleManager = FindAnyObjectByType<BattleManager>();
-
-        int focusBoost = battleManager.enemies.Count * 2;
+        focusBoost = battleManager != null ? battleManager.enemies.Count * 2 : 0;
         character.focus += focusBoost;
-
         Debug.Log($"{character.characterName} gains +{focusBoost} Focus from Nervous System Separator.");
+    }
+
+    public void DeApplyEffect(Character character)
+    {
+        character.focus -= focusBoost;
+        focusBoost = 0;
     }
 
     public void OnAfterDamage(Character source, Character target, int finalDamage)

--- a/LlmGame/Assets/Script/Item/NeurospikeBooster.cs
+++ b/LlmGame/Assets/Script/Item/NeurospikeBooster.cs
@@ -10,4 +10,9 @@ public class NeurospikeBooster : PassiveItemBase
     {
         character.speed += speedBoost;
     }
+
+    public override void DeApplyEffect(Character character)
+    {
+        character.speed -= speedBoost;
+    }
 }

--- a/LlmGame/Assets/Script/Item/PainConverter.cs
+++ b/LlmGame/Assets/Script/Item/PainConverter.cs
@@ -17,6 +17,11 @@ public class PainConverter : MonoBehaviour, IPassiveItem, IDamageReaction, ITurn
         // No immediate effect
     }
 
+    public void DeApplyEffect(Character character)
+    {
+        healedThisTurn = false;
+    }
+
     public void OnTurnStart(Character character)
     {
         healedThisTurn = false; // Reset for new turn

--- a/LlmGame/Assets/Script/Item/PassiveItemBase.cs
+++ b/LlmGame/Assets/Script/Item/PassiveItemBase.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 public abstract class PassiveItemBase : MonoBehaviour, IPassiveItem
 {
     public abstract void ApplyEffect(Character character);
+    public abstract void DeApplyEffect(Character character);
 
     public void OnAfterDamage(Character source, Character target, int finalDamage)
     {

--- a/LlmGame/Assets/Script/Item/PrecisionArms.cs
+++ b/LlmGame/Assets/Script/Item/PrecisionArms.cs
@@ -12,6 +12,8 @@ public class PrecisionArms : MonoBehaviour, IPassiveItem, IPossibilityModifier
         Debug.Log("🦾 Precision Arms equipped: +10% Critical Chance");
     }
 
+    public void DeApplyEffect(Character character) { }
+
     public void ModifyChances(PossibilityPool pool)
     {
         pool.AddModifier(StatusChanceType.Critical, critChanceBonus);

--- a/LlmGame/Assets/Script/Item/RangedWeaponFocus.cs
+++ b/LlmGame/Assets/Script/Item/RangedWeaponFocus.cs
@@ -22,6 +22,14 @@ public class RangedWeaponFocus : MonoBehaviour, IPassiveItem
         }
     }
 
+    public void DeApplyEffect(Character character)
+    {
+        if (character is Player player)
+        {
+            player.possibilityPool.AddModifier(StatusChanceType.Critical, -critBonus);
+        }
+    }
+
     public void OnAfterDamage(Character source, Character target, int finalDamage)
     {
         throw new System.NotImplementedException();

--- a/LlmGame/Assets/Script/Item/ReactiveShieldJacket.cs
+++ b/LlmGame/Assets/Script/Item/ReactiveShieldJacket.cs
@@ -9,4 +9,10 @@ public class ReactiveShieldJacket : PassiveItemBase
         character.maxShield += 25;
         character.currentshield += 25;
     }
+
+    public override void DeApplyEffect(Character character)
+    {
+        character.maxShield -= 25;
+        character.currentshield = Mathf.Clamp(character.currentshield - 25, 0, character.maxShield);
+    }
 }

--- a/LlmGame/Assets/Script/Item/RecoilStabilizerArmor.cs
+++ b/LlmGame/Assets/Script/Item/RecoilStabilizerArmor.cs
@@ -5,6 +5,7 @@ public class RecoilStabilizerArmor : MonoBehaviour, IPassiveItem, IDamageReactio
     private Character owner;
     private const int defenseBonus = 10;
     private const int damageBonus = 10;
+    private bool bonusApplied = false;
 
     public void ApplyEffect(Character character)
     {
@@ -14,6 +15,7 @@ public class RecoilStabilizerArmor : MonoBehaviour, IPassiveItem, IDamageReactio
         {
             character.defense += defenseBonus;
             Debug.Log($"🦴 Recoil Stabilizer equipped: +{defenseBonus} Defense when using ranged weapons.");
+            bonusApplied = true;
         }
     }
 
@@ -35,4 +37,15 @@ public class RecoilStabilizerArmor : MonoBehaviour, IPassiveItem, IDamageReactio
     }
 
     public void OnAfterDamage(Character source, Character target, int finalDamage) { }
+
+    public void DeApplyEffect(Character character)
+    {
+        if (character == owner && bonusApplied)
+        {
+            character.defense -= defenseBonus;
+            bonusApplied = false;
+        }
+        if (character == owner)
+            owner = null;
+    }
 }

--- a/LlmGame/Assets/Script/Item/SprintBoosters.cs
+++ b/LlmGame/Assets/Script/Item/SprintBoosters.cs
@@ -13,6 +13,11 @@ public class SprintBoosters : MonoBehaviour, IPassiveItem
         Debug.Log($"🦿 Sprint Boosters equipped: +{speedBonus} Speed to {character.characterName}");
     }
 
+    public void DeApplyEffect(Character character)
+    {
+        character.speed -= speedBonus;
+    }
+
     public void OnAfterDamage(Character source, Character target, int finalDamage)
     {
         throw new System.NotImplementedException();

--- a/LlmGame/Assets/Script/Item/StabilizerGloves.cs
+++ b/LlmGame/Assets/Script/Item/StabilizerGloves.cs
@@ -10,6 +10,12 @@ public class StabilizerGloves : MonoBehaviour, IPassiveItem, IDamageReaction
         owner = character;
     }
 
+    public void DeApplyEffect(Character character)
+    {
+        if (owner == character)
+            owner = null;
+    }
+
     public void OnBeforeDamage(Character source, Character target, ref int damage)
     {
         if (source != owner) return;

--- a/LlmGame/Assets/Script/Item/SyntheticPainLoop.cs
+++ b/LlmGame/Assets/Script/Item/SyntheticPainLoop.cs
@@ -9,8 +9,22 @@ public class SyntheticPainLoop : MonoBehaviour, IPassiveItem, IDamageReaction
     [SerializeField] private int maxStacks = 3;
 
     private int currentStacks = 0;
+    private Character owner;
 
-    public void ApplyEffect(Character character) { }
+    public void ApplyEffect(Character character)
+    {
+        owner = character;
+    }
+
+    public void DeApplyEffect(Character character)
+    {
+        if (owner == character)
+        {
+            character.attack -= currentStacks * attackBonus;
+            currentStacks = 0;
+            owner = null;
+        }
+    }
 
     public void OnBeforeDamage(Character source, Character target, ref int damage)
     {
@@ -22,19 +36,17 @@ public class SyntheticPainLoop : MonoBehaviour, IPassiveItem, IDamageReaction
         Debug.Log(source);
         Debug.Log(target);
 
-        if (target == null || source == null) return;
+        if (target == null || source == null || source != owner) return;
 
         if (!target.HasStatusEffect(StatusEffectType.Bleed)) return;
 
         // Make sure this passive is only applied for the attacker (source)
-        var character = source;
-
         if (currentStacks >= maxStacks)
             return;
 
-        character.attack += attackBonus;
+        owner.attack += attackBonus;
         currentStacks++;
 
-        Debug.Log($"🧬 Synthetic Pain Loop: {character.characterName} gains +{attackBonus} Attack (Total: +{currentStacks * attackBonus}) for damaging a bleeding enemy.");
+        Debug.Log($"🧬 Synthetic Pain Loop: {owner.characterName} gains +{attackBonus} Attack (Total: +{currentStacks * attackBonus}) for damaging a bleeding enemy.");
     }
 }

--- a/LlmGame/Assets/Script/Item/TacticalVisor.cs
+++ b/LlmGame/Assets/Script/Item/TacticalVisor.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 public class TacticalVisor : MonoBehaviour, IPassiveItem
 {
     private const int bonusRangedDamage = 10;
+    private bool applied = false;
 
     public void ApplyEffect(Character character)
     {
@@ -13,6 +14,16 @@ public class TacticalVisor : MonoBehaviour, IPassiveItem
         {
             character.attack += bonusRangedDamage;
             Debug.Log($"🔭 Tactical Visor equipped: +{bonusRangedDamage} Ranged Weapon Damage applied to {character.characterName}");
+            applied = true;
+        }
+    }
+
+    public void DeApplyEffect(Character character)
+    {
+        if (applied)
+        {
+            character.attack -= bonusRangedDamage;
+            applied = false;
         }
     }
 

--- a/LlmGame/Assets/Script/Item/TemporalFragment.cs
+++ b/LlmGame/Assets/Script/Item/TemporalFragment.cs
@@ -16,6 +16,16 @@ public class TemporalFragment : MonoBehaviour, IPassiveItem
         }
     }
 
+    public void DeApplyEffect(Character character)
+    {
+        var battleManager = FindObjectOfType<BattleManager>();
+        if (battleManager != null && battleManager.currentActingCharacter == character)
+        {
+            battleManager.currentActingCharacter = null;
+            battleManager.isActionPhase = false;
+        }
+    }
+
     public void OnAfterDamage(Character source, Character target, int finalDamage)
     {
         throw new System.NotImplementedException();

--- a/LlmGame/Assets/Script/Item/TitaniumLatticeArmor.cs
+++ b/LlmGame/Assets/Script/Item/TitaniumLatticeArmor.cs
@@ -8,4 +8,9 @@ public class TitaniumLatticeArmor : PassiveItemBase
     {
         character.defense += 5;
     }
+
+    public override void DeApplyEffect(Character character)
+    {
+        character.defense -= 5;
+    }
 }

--- a/LlmGame/Assets/Script/Item/ToxicVisor.cs
+++ b/LlmGame/Assets/Script/Item/ToxicVisor.cs
@@ -8,6 +8,8 @@ public class ToxicVisor : MonoBehaviour, IPassiveItem
         // No immediate effect on equip
     }
 
+    public void DeApplyEffect(Character character) { }
+
     public void OnAfterDamage(Character source, Character target, int finalDamage) { }
 
     public void OnBeforeDamage(Character source, Character target, ref int damage) { }

--- a/LlmGame/Assets/Script/Item/WeakpointTargetingSystem.cs
+++ b/LlmGame/Assets/Script/Item/WeakpointTargetingSystem.cs
@@ -27,6 +27,8 @@ public class WeakpointTargetingSystem : MonoBehaviour, IPassiveItem
 
     public void ApplyEffect(Character character) { }
 
+    public void DeApplyEffect(Character character) { }
+
     public void OnAfterDamage(Character source, Character target, int finalDamage)
     {
         throw new System.NotImplementedException();

--- a/LlmGame/Assets/Script/PlayerData.cs
+++ b/LlmGame/Assets/Script/PlayerData.cs
@@ -82,6 +82,11 @@ public class PlayerData : MonoBehaviour
     public void SavePlayer(Player player)
     {
         if (player == null) return;
+        foreach (var behavior in player.runtimePassiveBehaviors)
+        {
+            if (behavior is IPassiveItem item)
+                item.DeApplyEffect(player);
+        }
 
         attack = player.attack;
         defense = player.defense;
@@ -102,6 +107,12 @@ public class PlayerData : MonoBehaviour
         equippedPassiveItems = new List<PassiveItemData>(player.equippedPassiveItems);
 
         initialized = true;
+
+        foreach (var behavior in player.runtimePassiveBehaviors)
+        {
+            if (behavior is IPassiveItem item)
+                item.ApplyEffect(player);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- add `DeApplyEffect` to passive item interface and base class
- implement effect removal for all passive items
- remove item effects before saving player data to avoid stacking

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c554fd57c832299ca89959ca294fb