### PR TITLE
Refactor passive item runtime handling

### DIFF
--- a/LlmGame/Assets/ObjCharacter/PassiveItem/ContagionCore/ContagionCore.cs
+++ b/LlmGame/Assets/ObjCharacter/PassiveItem/ContagionCore/ContagionCore.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 public class ContagionCore : MonoBehaviour, IDeathListener, IPassiveItem
@@ -36,18 +37,7 @@ public class ContagionCore : MonoBehaviour, IDeathListener, IPassiveItem
             return;
 
         // Ensure player has this passive equipped
-        bool playerHasContagionCore = false;
-        foreach (var itemData in player.equippedPassiveItems)
-        {
-            if (itemData.itemPrefab == null) continue;
-
-            if (itemData.itemPrefab.GetComponent<ContagionCore>() != null)
-            {
-                playerHasContagionCore = true;
-                break;
-            }
-        }
-
+        bool playerHasContagionCore = player.runtimePassiveBehaviors.Any(b => b is ContagionCore);
         if (!playerHasContagionCore)
             return;
 

--- a/LlmGame/Assets/Script/Character.cs
+++ b/LlmGame/Assets/Script/Character.cs
@@ -75,6 +75,24 @@ public class Character : MonoBehaviour
     [SerializeField] public List<PassiveItemData> equippedPassiveItems;
     private Dictionary<string, int> customIntData = new();
 
+    public void EquipPassiveItem(PassiveItemData itemData)
+    {
+        if (itemData == null || equippedPassiveItems.Contains(itemData)) return;
+
+        equippedPassiveItems.Add(itemData);
+        itemData.EquipTo(this);
+    }
+
+    public void UnequipPassiveItem(PassiveItemData itemData)
+    {
+        if (itemData == null) return;
+
+        if (equippedPassiveItems.Remove(itemData))
+        {
+            EquipAllPassives();
+        }
+    }
+
     public virtual void Awake()
     {
         battleManager = FindAnyObjectByType<BattleManager>();
@@ -154,12 +172,9 @@ public class Character : MonoBehaviour
         Player player = FindObjectOfType<Player>();
         if (player != null)
         {
-            foreach (var itemData in player.equippedPassiveItems)
+            foreach (var behavior in player.runtimePassiveBehaviors)
             {
-                if (itemData.itemPrefab == null) continue;
-
-                var deathListener = itemData.itemPrefab.GetComponent<IDeathListener>();
-                if (deathListener != null)
+                if (behavior is IDeathListener deathListener)
                 {
                     deathListener.OnDeath(this);
                 }
@@ -444,12 +459,11 @@ public class Character : MonoBehaviour
 
                         Character source = effect.source;
 
-                        if (source != null)
+                        if (source is Player playerSource)
                         {
-                            foreach (var itemData in (source as Player)?.equippedPassiveItems ?? new List<PassiveItemData>())
+                            foreach (var behavior in playerSource.runtimePassiveBehaviors)
                             {
-                                if (itemData.itemPrefab == null) continue;
-                                if (itemData.itemPrefab.GetComponent<BloodTuner>() != null)
+                                if (behavior is BloodTuner)
                                 {
                                     spreadToAllParts = true;
                                     break;
@@ -562,11 +576,9 @@ public class Character : MonoBehaviour
     {
         if (source == null || !(source is Player playerSource)) return;
 
-        foreach (var itemData in playerSource.equippedPassiveItems)
+        foreach (var behavior in playerSource.runtimePassiveBehaviors)
         {
-            if (itemData.itemPrefab == null) continue;
-
-            if (itemData.itemPrefab.GetComponent<NerveRotVials>() != null)
+            if (behavior is NerveRotVials)
             {
                 // ✅ Limit to max 3 stacks
                 int currentStacks = activeStatusEffects
@@ -606,11 +618,9 @@ public class Character : MonoBehaviour
     {
         if (source == null || !(source is Player playerSource)) return;
 
-        foreach (var itemData in playerSource.equippedPassiveItems)
+        foreach (var behavior in playerSource.runtimePassiveBehaviors)
         {
-            if (itemData.itemPrefab == null) continue;
-
-            if (itemData.itemPrefab.GetComponent<IrradiationMatrix>() != null)
+            if (behavior is IrradiationMatrix)
             {
                 // Prevent duplicates
                 if (HasStatusEffect(StatusEffectType.HealReduction)) return;

--- a/LlmGame/Assets/Script/CharacterCombatHandler.cs
+++ b/LlmGame/Assets/Script/CharacterCombatHandler.cs
@@ -61,13 +61,6 @@ public class CharacterCombatHandler : MonoBehaviour
                 reaction.OnBeforeDamage(player, target, ref finalDamage);
         }
 
-        foreach (var item in player.equippedPassiveItems)
-        {
-            if (item.itemPrefab == null) continue;
-            var reaction = item.itemPrefab.GetComponent<IDamageReaction>();
-            if (reaction != null)
-                reaction.OnBeforeDamage(player, target, ref finalDamage);
-        }
 
         // Target passives, items, armor
         if (target is Player targetPlayer)
@@ -78,13 +71,6 @@ public class CharacterCombatHandler : MonoBehaviour
                     reaction.OnBeforeDamage(player, targetPlayer, ref finalDamage);
             }
 
-            foreach (var item in targetPlayer.equippedPassiveItems)
-            {
-                if (item.itemPrefab == null) continue;
-                var reaction = item.itemPrefab.GetComponent<IDamageReaction>();
-                if (reaction != null)
-                    reaction.OnBeforeDamage(player, targetPlayer, ref finalDamage);
-            }
 
             foreach (var bodyPart in targetPlayer.bodyParts)
             {
@@ -126,13 +112,6 @@ public class CharacterCombatHandler : MonoBehaviour
                     reaction.OnAfterDamage(player, targetAfter, finalDamage);
             }
 
-            foreach (var item in targetAfter.equippedPassiveItems)
-            {
-                if (item.itemPrefab == null) continue;
-                var reaction = item.itemPrefab.GetComponent<IDamageReaction>();
-                if (reaction != null)
-                    reaction.OnAfterDamage(player, targetAfter, finalDamage);
-            }
 
             foreach (var bodyPart in targetAfter.bodyParts)
             {
@@ -155,13 +134,6 @@ public class CharacterCombatHandler : MonoBehaviour
                 reaction.OnAfterDamage(player, target, finalDamage);
         }
 
-        foreach (var item in player.equippedPassiveItems)
-        {
-            if (item.itemPrefab == null) continue;
-            var reaction = item.itemPrefab.GetComponent<IDamageReaction>();
-            if (reaction != null)
-                reaction.OnAfterDamage(player, target, finalDamage);
-        }
 
         // ✅ Log
         //string log = $"Turn {battleManager.turnCount}: {player.characterName} {battleManager.playerInputField.text}  → Target: {target.characterName} Result: {target.currentHP} / {target.maxHP} ({battleManager.chatAI.baseEffect})";
@@ -191,15 +163,9 @@ public class CharacterCombatHandler : MonoBehaviour
             }
 
             // 🔁 PassiveItemData prefabs (optional if stateless)
-            foreach (var itemData in player.equippedPassiveItems)
+            foreach (var listener in player.runtimePassiveBehaviors.OfType<ITurnListener>())
             {
-                if (itemData.itemPrefab == null) continue;
-
-                ITurnListener prefabListener = itemData.itemPrefab.GetComponent<ITurnListener>();
-                if (prefabListener != null)
-                {
-                    prefabListener.OnTurnEnd(player);
-                }
+                listener.OnTurnEnd(player);
             }
         }
 
@@ -263,13 +229,6 @@ public class CharacterCombatHandler : MonoBehaviour
             }
 
             // Equipped passive items
-            foreach (var item in playerTarget.equippedPassiveItems)
-            {
-                if (item.itemPrefab == null) continue;
-                var reaction = item.itemPrefab.GetComponent<IDamageReaction>();
-                if (reaction != null)
-                    reaction.OnBeforeDamage(enemy, playerTarget, ref finalDamage);
-            }
 
             // Armor on body parts
             foreach (var part in playerTarget.bodyParts)
@@ -309,13 +268,6 @@ public class CharacterCombatHandler : MonoBehaviour
                     reaction.OnAfterDamage(enemy, playerAfter, finalDamage);
             }
 
-            foreach (var item in playerAfter.equippedPassiveItems)
-            {
-                if (item.itemPrefab == null) continue;
-                var reaction = item.itemPrefab.GetComponent<IDamageReaction>();
-                if (reaction != null)
-                    reaction.OnAfterDamage(enemy, playerAfter, finalDamage);
-            }
 
             foreach (var part in playerAfter.bodyParts)
             {

--- a/LlmGame/Assets/Script/DamageCalculator.cs
+++ b/LlmGame/Assets/Script/DamageCalculator.cs
@@ -248,12 +248,9 @@ public class DamageCalculator : MonoBehaviour
                 // 🔥 Apply OnHit Modifiers from Passive Items (like Head Targeting)
                 if (attacker is Player attackerPlayer)
                 {
-                    foreach (var itemData in attackerPlayer.equippedPassiveItems)
+                    foreach (var behavior in attackerPlayer.runtimePassiveBehaviors)
                     {
-                        if (itemData.itemPrefab == null) continue;
-
-                        IHitModifier hitModifier = itemData.itemPrefab.GetComponent<IHitModifier>();
-                        if (hitModifier != null)
+                        if (behavior is IHitModifier hitModifier)
                         {
                             hitModifier.OnHit(attacker, part, ref damageToApply);
                         }
@@ -458,12 +455,9 @@ public class DamageCalculator : MonoBehaviour
                     // 🔥 Apply OnHit Modifiers
                     if (attacker is Player attackerPlayer)
                     {
-                        foreach (var itemData in attackerPlayer.equippedPassiveItems)
+                        foreach (var behavior in attackerPlayer.runtimePassiveBehaviors)
                         {
-                            if (itemData.itemPrefab == null) continue;
-
-                            IHitModifier hitModifier = itemData.itemPrefab.GetComponent<IHitModifier>();
-                            if (hitModifier != null)
+                            if (behavior is IHitModifier hitModifier)
                             {
                                 hitModifier.OnHit(attacker, part, ref damageToApply);
                             }
@@ -483,12 +477,9 @@ public class DamageCalculator : MonoBehaviour
                     // 🔥 Apply OnHit Modifiers
                     if (attacker is Player attackerPlayer)
                     {
-                        foreach (var itemData in attackerPlayer.equippedPassiveItems)
+                        foreach (var behavior in attackerPlayer.runtimePassiveBehaviors)
                         {
-                            if (itemData.itemPrefab == null) continue;
-
-                            IHitModifier hitModifier = itemData.itemPrefab.GetComponent<IHitModifier>();
-                            if (hitModifier != null)
+                            if (behavior is IHitModifier hitModifier)
                             {
                                 hitModifier.OnHit(attacker, part, ref damageToApply);
                             }

--- a/LlmGame/Assets/Script/Item/PassiveItemData.cs
+++ b/LlmGame/Assets/Script/Item/PassiveItemData.cs
@@ -26,6 +26,8 @@ public class PassiveItemData : ScriptableObject
         // ✅ Instantiate the prefab
         GameObject instance = Instantiate(itemPrefab, character.transform);
 
+        character.RegisterRuntimePassive(instance);
+
         // ✅ Apply effect
         var passiveComponent = instance.GetComponent<IPassiveItem>();
         if (passiveComponent != null)

--- a/LlmGame/Assets/Script/MysterySceneEventHandler.cs
+++ b/LlmGame/Assets/Script/MysterySceneEventHandler.cs
@@ -118,15 +118,17 @@ public class MysterySceneEventHandler : MonoBehaviour
     public void OrderNoodles()
     {
         ChangeMoney(-smallCreditCost);
-        if (msgNoodleItem != null && player != null && !player.equippedPassiveItems.Contains(msgNoodleItem))
+        if (msgNoodleItem != null && player != null)
         {
-            player.equippedPassiveItems.Add(msgNoodleItem);
-            msgNoodleItem.EquipTo(player);
-            Log($"Received passive item: {msgNoodleItem.name}");
-        }
-        else
-        {
-            Log("MSG noodle item not granted (missing item/player or already owned).");
+            if (!player.equippedPassiveItems.Contains(msgNoodleItem))
+            {
+                player.EquipPassiveItem(msgNoodleItem);
+                Log($"Received passive item: {msgNoodleItem.name}");
+            }
+            else
+            {
+                Log("MSG noodle item not granted (missing item/player or already owned).");
+            }
         }
         QueueNextMystery();
     }
@@ -411,7 +413,7 @@ public class MysterySceneEventHandler : MonoBehaviour
         int idx = Random.Range(0, player.equippedPassiveItems.Count);
         var removedItem = player.equippedPassiveItems[idx];
         ItemRarity rarity = removedItem.rarity;
-        player.equippedPassiveItems.RemoveAt(idx);
+        player.UnequipPassiveItem(removedItem);
         Log($"Traded away: {removedItem.name} (Rarity: {rarity})");
         GrantRandomItem(rarity);
         QueueNextMystery();

--- a/LlmGame/Assets/Script/ShopSceneController.cs
+++ b/LlmGame/Assets/Script/ShopSceneController.cs
@@ -136,8 +136,7 @@ public class ShopSceneController : MonoBehaviour
 
         if (obj is PassiveItemData passive)
         {
-            if (!player.equippedPassiveItems.Contains(passive))
-                player.equippedPassiveItems.Add(passive);
+            player.EquipPassiveItem(passive);
         }
         else if (obj is ArmorData armor)
         {

--- a/LlmGame/Assets/Script/StoreSystem.cs
+++ b/LlmGame/Assets/Script/StoreSystem.cs
@@ -40,8 +40,7 @@ public class StoreSystem : MonoBehaviour
     {
         if (item is PassiveItemData passive)
         {
-            if (!player.equippedPassiveItems.Contains(passive))
-                player.equippedPassiveItems.Add(passive);
+            player.EquipPassiveItem(passive);
         }
         else if (item is ArmorData armor)
         {


### PR DESCRIPTION
## Summary
- unify passive item and runtime behavior processing
- register passive item behaviours during equip and rely on runtimePassiveBehaviors
- update damage and combat handlers to use unified list

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c607359b08322997189fd8e849052