### PR TITLE
refactor: remove equipped passive item list from character

### DIFF
--- a/LlmGame/Assets/Prefabs/Character/Enemy/Zhuyi easy.prefab
+++ b/LlmGame/Assets/Prefabs/Character/Enemy/Zhuyi easy.prefab
@@ -215,6 +215,5 @@ MonoBehaviour:
   rightHandWeapon: {fileID: 11400000, guid: 5eb97eab966aeda4d8df1114c3fcc71e, type: 2}
   activeItem: []
   isUsingConsumeTurnItem: 0
-  equippedPassiveItems: []
   archetype: 0
   actions: []

--- a/LlmGame/Assets/Prefabs/Character/Player/Houyi MC.prefab
+++ b/LlmGame/Assets/Prefabs/Character/Player/Houyi MC.prefab
@@ -256,7 +256,6 @@ MonoBehaviour:
   rightHandWeapon: {fileID: 0}
   activeItem: []
   isUsingConsumeTurnItem: 0
-  equippedPassiveItems: []
 --- !u!114 &7262446337314057770
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/LlmGame/Assets/Script/Character.cs
+++ b/LlmGame/Assets/Script/Character.cs
@@ -72,22 +72,23 @@ public class Character : MonoBehaviour
     public bool isUsingConsumeTurnItem;
 
     public PossibilityPool possibilityPool { get; private set; }
-    [SerializeField] public List<PassiveItemData> equippedPassiveItems;
     private Dictionary<string, int> customIntData = new();
 
     public void EquipPassiveItem(PassiveItemData itemData)
     {
-        if (itemData == null || equippedPassiveItems.Contains(itemData)) return;
+        if (itemData == null) return;
+        var list = PlayerData.Instance?.equippedPassiveItems;
+        if (list != null && list.Contains(itemData)) return;
 
-        equippedPassiveItems.Add(itemData);
+        list?.Add(itemData);
         itemData.EquipTo(this);
     }
 
     public void UnequipPassiveItem(PassiveItemData itemData)
     {
         if (itemData == null) return;
-
-        if (equippedPassiveItems.Remove(itemData))
+        var list = PlayerData.Instance?.equippedPassiveItems;
+        if (list != null && list.Remove(itemData))
         {
             EquipAllPassives();
         }
@@ -704,9 +705,13 @@ public class Character : MonoBehaviour
     {
         runtimePassiveBehaviors.Clear(); // Reset to avoid duplicates
 
-        foreach (var item in equippedPassiveItems)
+        var list = PlayerData.Instance?.equippedPassiveItems;
+        if (list != null)
         {
-            item.EquipTo(this); // this handles tracking internally
+            foreach (var item in list)
+            {
+                item.EquipTo(this); // this handles tracking internally
+            }
         }
 
         foreach (var part in bodyParts)

--- a/LlmGame/Assets/Script/MysterySceneEventHandler.cs
+++ b/LlmGame/Assets/Script/MysterySceneEventHandler.cs
@@ -120,7 +120,7 @@ public class MysterySceneEventHandler : MonoBehaviour
         ChangeMoney(-smallCreditCost);
         if (msgNoodleItem != null && player != null)
         {
-            if (!player.equippedPassiveItems.Contains(msgNoodleItem))
+            if (!PlayerData.Instance.equippedPassiveItems.Contains(msgNoodleItem))
             {
                 player.EquipPassiveItem(msgNoodleItem);
                 Log($"Received passive item: {msgNoodleItem.name}");
@@ -403,15 +403,15 @@ public class MysterySceneEventHandler : MonoBehaviour
 
     public void TradeWithHomeless()
     {
-        if (player == null || player.equippedPassiveItems.Count == 0)
+        if (player == null || PlayerData.Instance.equippedPassiveItems.Count == 0)
         {
             Log("Trade failed: no items equipped to trade.");
             QueueNextMystery();
             return;
         }
 
-        int idx = Random.Range(0, player.equippedPassiveItems.Count);
-        var removedItem = player.equippedPassiveItems[idx];
+        int idx = Random.Range(0, PlayerData.Instance.equippedPassiveItems.Count);
+        var removedItem = PlayerData.Instance.equippedPassiveItems[idx];
         ItemRarity rarity = removedItem.rarity;
         player.UnequipPassiveItem(removedItem);
         Log($"Traded away: {removedItem.name} (Rarity: {rarity})");

--- a/LlmGame/Assets/Script/PlayerData.cs
+++ b/LlmGame/Assets/Script/PlayerData.cs
@@ -112,7 +112,6 @@ public class PlayerData : MonoBehaviour
         inventoryArmors = new List<ArmorData>(player.inventoryArmors);
         leftHandWeapon = player.leftHandWeapon;
         rightHandWeapon = player.rightHandWeapon;
-        equippedPassiveItems = new List<PassiveItemData>(player.equippedPassiveItems);
 
         // Save equipped armors from body parts
         equippedArmors = new List<EquippedArmorEntry>();
@@ -168,7 +167,6 @@ public class PlayerData : MonoBehaviour
         player.inventoryArmors = new List<ArmorData>(inventoryArmors);
         player.leftHandWeapon = leftHandWeapon;
         player.rightHandWeapon = rightHandWeapon;
-        player.equippedPassiveItems = new List<PassiveItemData>(equippedPassiveItems);
 
         // Load equipped armor into body parts
         foreach (var part in player.bodyParts)

--- a/LlmGame/Assets/Script/StoreSystem.cs
+++ b/LlmGame/Assets/Script/StoreSystem.cs
@@ -54,7 +54,7 @@ public class StoreSystem : MonoBehaviour
     {
         var pool = new List<ScriptableObject>();
 
-        var ownedPassives = new HashSet<PassiveItemData>(player.equippedPassiveItems);
+        var ownedPassives = new HashSet<PassiveItemData>(PlayerData.Instance.equippedPassiveItems);
 
         var ownedArmors = new HashSet<ArmorData>(
             player.bodyParts.Where(p => p.equippedArmor != null).Select(p => p.equippedArmor)


### PR DESCRIPTION
## Summary
- remove `equippedPassiveItems` from `Character` and rely on PlayerData's passive list
- update passive item checks in mystery events and store system
- drop obsolete `equippedPassiveItems` entries from character prefabs

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c641445e08322b451fd9ca1ed5cd0