### PR TITLE
Avoid duplicate passive stat boosts

### DIFF
--- a/LlmGame/Assets/Script/Character.cs
+++ b/LlmGame/Assets/Script/Character.cs
@@ -725,7 +725,17 @@ public class Character : MonoBehaviour
         foreach (var comp in instance.GetComponents<MonoBehaviour>())
         {
             runtimePassiveBehaviors.Add(comp);
-            if (comp is IPassiveItem item) item.ApplyEffect(this);
+
+            if (comp is IPassiveItem item)
+            {
+                string typeName = comp.GetType().FullName;
+                var applied = PlayerData.Instance?.appliedPassiveItemTypes;
+                if (applied != null && !applied.Contains(typeName))
+                {
+                    item.ApplyEffect(this);
+                    applied.Add(typeName);
+                }
+            }
         }
     }
 

--- a/LlmGame/Assets/Script/PlayerData.cs
+++ b/LlmGame/Assets/Script/PlayerData.cs
@@ -29,6 +29,9 @@ public class PlayerData : MonoBehaviour
     public Weapon rightHandWeapon;
     public List<PassiveItemData> equippedPassiveItems = new List<PassiveItemData>();
 
+    // Tracks which passive item effects have already been applied to avoid stacking
+    public HashSet<string> appliedPassiveItemTypes = new HashSet<string>();
+
     // Equipped armor per body part
     public List<EquippedArmorEntry> equippedArmors = new List<EquippedArmorEntry>();
 
@@ -79,6 +82,9 @@ public class PlayerData : MonoBehaviour
         equippedPassiveItems = config ? new List<PassiveItemData>(config.startingPassives) : new List<PassiveItemData>();
 
         equippedArmors = new List<EquippedArmorEntry>(); // remains empty unless equipped manually
+
+        // Clear any previously applied passive effects for a fresh game
+        appliedPassiveItemTypes = new HashSet<string>();
 
         initialized = true;
     }


### PR DESCRIPTION
## Summary
- track passive item types already applied to the player
- apply passive stat boosts only once when registering runtime passives

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c740a1eb083228455d3d0aa60f13f