### PR TITLE
Track passive item bonuses across scenes

### DIFF
--- a/LlmGame/Assets/Script/BodyPartData.cs
+++ b/LlmGame/Assets/Script/BodyPartData.cs
@@ -63,14 +63,7 @@ public class BodyPartData : ScriptableObject
             return;
 
         GameObject instance = Instantiate(equippedArmor.itemBehaviorPrefab, character.transform);
-
-        foreach (var component in instance.GetComponents<MonoBehaviour>())
-        {
-            character.runtimePassiveBehaviors.Add(component);
-
-            if (component is IPassiveItem passive)
-                passive.ApplyEffect(character);
-        }
+        character.RegisterRuntimePassive(instance);
 
         Debug.Log($"✅ Equipped armor with behavior: {equippedArmor.armorName}");
     }

--- a/LlmGame/Assets/Script/Character.cs
+++ b/LlmGame/Assets/Script/Character.cs
@@ -25,6 +25,15 @@ public class Character : MonoBehaviour
     public int speed;
     public int maxShield;
 
+    [Header("Bonus Stats")]
+    public int bonusAttack;
+    public int bonusDefense;
+    public int bonusFocus;
+    public int bonusMaxHP;
+    public int bonusMaxMP;
+    public int bonusSpeed;
+    public int bonusMaxShield;
+
     [Header("Resource")]
     public int money;
 

--- a/LlmGame/Assets/Script/Item/AdaptiveSyncCore.cs
+++ b/LlmGame/Assets/Script/Item/AdaptiveSyncCore.cs
@@ -7,24 +7,36 @@ public class AdaptiveSyncCore : PassiveItemBase
     public override void ApplyEffect(Character character)
     {
         character.attack += 5;
+        character.bonusAttack += 5;
         character.defense += 5;
+        character.bonusDefense += 5;
         character.focus += 5;
+        character.bonusFocus += 5;
         character.maxHP += 5;
+        character.bonusMaxHP += 5;
         character.currentHP += 5;
         character.maxMP += 5;
+        character.bonusMaxMP += 5;
         character.currentMP += 5;
         character.speed += 5;
+        character.bonusSpeed += 5;
     }
 
     public override void DeApplyEffect(Character character)
     {
         character.attack -= 5;
+        character.bonusAttack -= 5;
         character.defense -= 5;
+        character.bonusDefense -= 5;
         character.focus -= 5;
+        character.bonusFocus -= 5;
         character.maxHP -= 5;
+        character.bonusMaxHP -= 5;
         character.currentHP = Mathf.Clamp(character.currentHP - 5, 0, character.maxHP);
         character.maxMP -= 5;
+        character.bonusMaxMP -= 5;
         character.currentMP = Mathf.Clamp(character.currentMP - 5, 0, character.maxMP);
         character.speed -= 5;
+        character.bonusSpeed -= 5;
     }
 }

--- a/LlmGame/Assets/Script/Item/BioCapacitorImplant.cs
+++ b/LlmGame/Assets/Script/Item/BioCapacitorImplant.cs
@@ -7,12 +7,14 @@ public class BioCapacitorImplant : PassiveItemBase
     public override void ApplyEffect(Character character)
     {
         character.maxMP += 15;
+        character.bonusMaxMP += 15;
         character.currentMP += 15;
     }
 
     public override void DeApplyEffect(Character character)
     {
         character.maxMP -= 15;
+        character.bonusMaxMP -= 15;
         character.currentMP = Mathf.Clamp(character.currentMP - 15, 0, character.maxMP);
     }
 }

--- a/LlmGame/Assets/Script/Item/CognitiveLoopEnhancer.cs
+++ b/LlmGame/Assets/Script/Item/CognitiveLoopEnhancer.cs
@@ -7,10 +7,12 @@ public class CognitiveLoopEnhancer : PassiveItemBase
     public override void ApplyEffect(Character character)
     {
         character.focus += 5;
+        character.bonusFocus += 5;
     }
 
     public override void DeApplyEffect(Character character)
     {
         character.focus -= 5;
+        character.bonusFocus -= 5;
     }
 }

--- a/LlmGame/Assets/Script/Item/CombatGrips.cs
+++ b/LlmGame/Assets/Script/Item/CombatGrips.cs
@@ -16,6 +16,7 @@ public class CombatGrips : MonoBehaviour, IPassiveItem
         {
             bonusAttack = Mathf.RoundToInt(character.attack * meleeDamageMultiplier);
             character.attack += bonusAttack;
+            character.bonusAttack += bonusAttack;
 
             Debug.Log($"🥊 Combat Grips equipped: +{bonusAttack} Attack (+10%) for melee weapon.");
         }
@@ -31,6 +32,7 @@ public class CombatGrips : MonoBehaviour, IPassiveItem
         if (bonusAttack != 0)
         {
             character.attack -= bonusAttack;
+            character.bonusAttack -= bonusAttack;
             bonusAttack = 0;
         }
     }

--- a/LlmGame/Assets/Script/Item/CombatMemoryChip.cs
+++ b/LlmGame/Assets/Script/Item/CombatMemoryChip.cs
@@ -9,11 +9,13 @@ public class CombatMemoryChip : PassiveItemBase
     {
         bonus = (character.focus / 3) * 2;
         character.attack += bonus;
+        character.bonusAttack += bonus;
     }
 
     public override void DeApplyEffect(Character character)
     {
         character.attack -= bonus;
+        character.bonusAttack -= bonus;
         bonus = 0;
     }
 }

--- a/LlmGame/Assets/Script/Item/EmbeddedPainkiller.cs
+++ b/LlmGame/Assets/Script/Item/EmbeddedPainkiller.cs
@@ -11,12 +11,14 @@ public class EmbeddedPainkiller : MonoBehaviour, IPassiveItem, IDamageReaction
     {
         Debug.Log("ApplyEffect EmbeddedPainkiller");
         character.maxHP += 15;
+        character.bonusMaxHP += 15;
         character.currentHP += 15;
     }
 
     public void DeApplyEffect(Character character)
     {
         character.maxHP -= 15;
+        character.bonusMaxHP -= 15;
         character.currentHP = Mathf.Clamp(character.currentHP - 15, 0, character.maxHP);
     }
 

--- a/LlmGame/Assets/Script/Item/MSGNoodle.cs
+++ b/LlmGame/Assets/Script/Item/MSGNoodle.cs
@@ -7,12 +7,14 @@ public class MSGNoodle : PassiveItemBase
     public override void ApplyEffect(Character character)
     {
         character.maxHP += 10;
+        character.bonusMaxHP += 10;
         character.currentHP += 10;
     }
 
     public override void DeApplyEffect(Character character)
     {
         character.maxHP -= 10;
+        character.bonusMaxHP -= 10;
         character.currentHP = Mathf.Clamp(character.currentHP - 10, 0, character.maxHP);
     }
 }

--- a/LlmGame/Assets/Script/Item/NanoVascularMicrorobot.cs
+++ b/LlmGame/Assets/Script/Item/NanoVascularMicrorobot.cs
@@ -8,12 +8,14 @@ public class NanoVascularMicrorobot : PassiveItemBase
     {
         Debug.Log("NanoVascularMicrorobot");
         character.maxHP += 25;
+        character.bonusMaxHP += 25;
         character.currentHP += 25;
     }
 
     public override void DeApplyEffect(Character character)
     {
         character.maxHP -= 25;
+        character.bonusMaxHP -= 25;
         character.currentHP = Mathf.Clamp(character.currentHP - 25, 0, character.maxHP);
     }
 }

--- a/LlmGame/Assets/Script/Item/NervousSystemSeparator.cs
+++ b/LlmGame/Assets/Script/Item/NervousSystemSeparator.cs
@@ -12,12 +12,14 @@ public class NervousSystemSeparator : MonoBehaviour, IPassiveItem
         BattleManager battleManager = FindAnyObjectByType<BattleManager>();
         focusBoost = battleManager != null ? battleManager.enemies.Count * 2 : 0;
         character.focus += focusBoost;
+        character.bonusFocus += focusBoost;
         Debug.Log($"{character.characterName} gains +{focusBoost} Focus from Nervous System Separator.");
     }
 
     public void DeApplyEffect(Character character)
     {
         character.focus -= focusBoost;
+        character.bonusFocus -= focusBoost;
         focusBoost = 0;
     }
 

--- a/LlmGame/Assets/Script/Item/NeurospikeBooster.cs
+++ b/LlmGame/Assets/Script/Item/NeurospikeBooster.cs
@@ -9,10 +9,12 @@ public class NeurospikeBooster : PassiveItemBase
     public override void ApplyEffect(Character character)
     {
         character.speed += speedBoost;
+        character.bonusSpeed += speedBoost;
     }
 
     public override void DeApplyEffect(Character character)
     {
         character.speed -= speedBoost;
+        character.bonusSpeed -= speedBoost;
     }
 }

--- a/LlmGame/Assets/Script/Item/ReactiveShieldJacket.cs
+++ b/LlmGame/Assets/Script/Item/ReactiveShieldJacket.cs
@@ -7,12 +7,14 @@ public class ReactiveShieldJacket : PassiveItemBase
     public override void ApplyEffect(Character character)
     {
         character.maxShield += 25;
+        character.bonusMaxShield += 25;
         character.currentshield += 25;
     }
 
     public override void DeApplyEffect(Character character)
     {
         character.maxShield -= 25;
+        character.bonusMaxShield -= 25;
         character.currentshield = Mathf.Clamp(character.currentshield - 25, 0, character.maxShield);
     }
 }

--- a/LlmGame/Assets/Script/Item/RecoilStabilizerArmor.cs
+++ b/LlmGame/Assets/Script/Item/RecoilStabilizerArmor.cs
@@ -14,6 +14,7 @@ public class RecoilStabilizerArmor : MonoBehaviour, IPassiveItem, IDamageReactio
         if (weapon != null && weapon.weaponType == WeaponType.Ranged_Weapon)
         {
             character.defense += defenseBonus;
+            character.bonusDefense += defenseBonus;
             Debug.Log($"🦴 Recoil Stabilizer equipped: +{defenseBonus} Defense when using ranged weapons.");
             bonusApplied = true;
         }
@@ -43,6 +44,7 @@ public class RecoilStabilizerArmor : MonoBehaviour, IPassiveItem, IDamageReactio
         if (character == owner && bonusApplied)
         {
             character.defense -= defenseBonus;
+            character.bonusDefense -= defenseBonus;
             bonusApplied = false;
         }
         if (character == owner)

--- a/LlmGame/Assets/Script/Item/SprintBoosters.cs
+++ b/LlmGame/Assets/Script/Item/SprintBoosters.cs
@@ -10,12 +10,14 @@ public class SprintBoosters : MonoBehaviour, IPassiveItem
     public void ApplyEffect(Character character)
     {
         character.speed += speedBonus;
+        character.bonusSpeed += speedBonus;
         Debug.Log($"🦿 Sprint Boosters equipped: +{speedBonus} Speed to {character.characterName}");
     }
 
     public void DeApplyEffect(Character character)
     {
         character.speed -= speedBonus;
+        character.bonusSpeed -= speedBonus;
     }
 
     public void OnAfterDamage(Character source, Character target, int finalDamage)

--- a/LlmGame/Assets/Script/Item/TacticalVisor.cs
+++ b/LlmGame/Assets/Script/Item/TacticalVisor.cs
@@ -13,6 +13,7 @@ public class TacticalVisor : MonoBehaviour, IPassiveItem
         if (character.rightHandWeapon != null && character.rightHandWeapon.weaponType == WeaponType.Ranged_Weapon)
         {
             character.attack += bonusRangedDamage;
+            character.bonusAttack += bonusRangedDamage;
             Debug.Log($"🔭 Tactical Visor equipped: +{bonusRangedDamage} Ranged Weapon Damage applied to {character.characterName}");
             applied = true;
         }
@@ -23,6 +24,7 @@ public class TacticalVisor : MonoBehaviour, IPassiveItem
         if (applied)
         {
             character.attack -= bonusRangedDamage;
+            character.bonusAttack -= bonusRangedDamage;
             applied = false;
         }
     }

--- a/LlmGame/Assets/Script/Item/TitaniumLatticeArmor.cs
+++ b/LlmGame/Assets/Script/Item/TitaniumLatticeArmor.cs
@@ -7,10 +7,12 @@ public class TitaniumLatticeArmor : PassiveItemBase
     public override void ApplyEffect(Character character)
     {
         character.defense += 5;
+        character.bonusDefense += 5;
     }
 
     public override void DeApplyEffect(Character character)
     {
         character.defense -= 5;
+        character.bonusDefense -= 5;
     }
 }

--- a/LlmGame/Assets/Script/PlayerData.cs
+++ b/LlmGame/Assets/Script/PlayerData.cs
@@ -96,17 +96,17 @@ public class PlayerData : MonoBehaviour
     {
         if (player == null) return;
 
-        attack = player.attack;
-        defense = player.defense;
-        focus = player.focus;
-        maxHP = player.maxHP;
-        maxMP = player.maxMP;
-        speed = player.speed;
-        maxShield = player.maxShield;
+        attack = player.attack - player.bonusAttack;
+        defense = player.defense - player.bonusDefense;
+        focus = player.focus - player.bonusFocus;
+        maxHP = player.maxHP - player.bonusMaxHP;
+        maxMP = player.maxMP - player.bonusMaxMP;
+        speed = player.speed - player.bonusSpeed;
+        maxShield = player.maxShield - player.bonusMaxShield;
 
-        currentHP = player.currentHP;
-        currentMP = player.currentMP;
-        currentShield = player.currentshield;
+        currentHP = Mathf.Clamp(player.currentHP, 0, maxHP);
+        currentMP = Mathf.Clamp(player.currentMP, 0, maxMP);
+        currentShield = Mathf.Clamp(player.currentshield, 0, maxShield);
         money = player.money;
 
         inventoryItems = new List<Item>(player.inventoryItems);
@@ -152,6 +152,14 @@ public class PlayerData : MonoBehaviour
         player.maxMP = maxMP;
         player.speed = speed;
         player.maxShield = maxShield;
+
+        player.bonusAttack = 0;
+        player.bonusDefense = 0;
+        player.bonusFocus = 0;
+        player.bonusMaxHP = 0;
+        player.bonusMaxMP = 0;
+        player.bonusSpeed = 0;
+        player.bonusMaxShield = 0;
 
         player.currentHP = Mathf.Clamp(currentHP, 0, maxHP);
         player.currentMP = Mathf.Clamp(currentMP, 0, maxMP);


### PR DESCRIPTION
## Summary
- Add bonus stat fields to `Character` so passive effects can be reapplied without stacking
- Reset and save these bonuses via `PlayerData` to keep base stats intact between scenes
- Update passive item scripts to record their bonuses and avoid duplicate armor effects

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c7c83e954832295e5a2d411052b12