### PR TITLE
Fix armor equip bug by tracking per-part armor

### DIFF
--- a/LlmGame/Assets/Script/BodyPartData.cs
+++ b/LlmGame/Assets/Script/BodyPartData.cs
@@ -59,13 +59,23 @@ public class BodyPartData : ScriptableObject
 
     public void EquipArmorTo(Character character)
     {
-        if (equippedArmor == null || equippedArmor.itemBehaviorPrefab == null)
+        ArmorData armorToEquip = equippedArmor;
+
+        if (character != null && character.equippedArmorByPart != null)
+        {
+            if (character.equippedArmorByPart.TryGetValue(type, out var storedArmor) && storedArmor != null)
+            {
+                armorToEquip = storedArmor;
+            }
+        }
+
+        if (armorToEquip == null || armorToEquip.itemBehaviorPrefab == null)
             return;
 
-        GameObject instance = Instantiate(equippedArmor.itemBehaviorPrefab, character.transform);
+        GameObject instance = Instantiate(armorToEquip.itemBehaviorPrefab, character.transform);
         character.RegisterRuntimePassive(instance);
 
-        Debug.Log($"✅ Equipped armor with behavior: {equippedArmor.armorName}");
+        Debug.Log($"✅ Equipped armor with behavior: {armorToEquip.armorName}");
     }
 
     public bool TryEquipArmor(ArmorData armor)

--- a/LlmGame/Assets/Script/Character.cs
+++ b/LlmGame/Assets/Script/Character.cs
@@ -75,6 +75,7 @@ public class Character : MonoBehaviour
     [Header("Equipment")]
     public Weapon leftHandWeapon;
     public Weapon rightHandWeapon;
+    public Dictionary<BodyPartType, ArmorData> equippedArmorByPart = new();
 
     [Header("Active Items")]
     public List<Item> activeItem;

--- a/LlmGame/Assets/Script/PlayerData.cs
+++ b/LlmGame/Assets/Script/PlayerData.cs
@@ -171,13 +171,19 @@ public class PlayerData : MonoBehaviour
         player.leftHandWeapon = leftHandWeapon;
         player.rightHandWeapon = rightHandWeapon;
 
-        // Load equipped armor into body parts
+        // Load equipped armor into body parts and runtime map
+        player.equippedArmorByPart = new Dictionary<BodyPartType, ArmorData>();
         foreach (var part in player.bodyParts)
         {
             if (part == null) continue;
 
             var match = equippedArmors.Find(e => e.bodyPartType == part.type);
             part.equippedArmor = match != null ? match.equippedArmor : null;
+
+            if (part.equippedArmor != null)
+            {
+                player.equippedArmorByPart[part.type] = part.equippedArmor;
+            }
         }
 
         // ✅ Re-apply passive and armor effects after loading


### PR DESCRIPTION
## Summary
- track equipped armor by body part on characters
- load armor mapping from saved data and use it when equipping passives

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d97e011fc832280bc0f3f7db94ca0