### PR TITLE
Implement battle inventory and weapon equipment UI

### DIFF
--- a/LlmGame/Assets/Script/BattleManager.cs
+++ b/LlmGame/Assets/Script/BattleManager.cs
@@ -479,9 +479,13 @@ public class BattleManager : MonoBehaviour
     public void EndPlayerTurn()
     {
         isActionPhase = false;
-        currentActingCharacter = null;
-        selectedTarget = null;
-        selectedParts.Clear();
+       currentActingCharacter = null;
+       selectedTarget = null;
+       selectedParts.Clear();
+
+        // Refresh inventory visuals in case items were consumed or equipment changed
+        var inventoryUI = FindObjectOfType<BattleInventoryUI>();
+        inventoryUI?.RefreshUI();
 
         chatAI.ShowInputUI(); // Reset UI
         Debug.Log("Player turn ended.");

--- a/LlmGame/Assets/Script/UI/BattleInventoryUI.cs
+++ b/LlmGame/Assets/Script/UI/BattleInventoryUI.cs
@@ -1,0 +1,107 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class BattleInventoryUI : MonoBehaviour
+{
+    [Header("References")]
+    public Player player;
+    public BattleManager battleManager;
+
+    [Header("Inventory Containers")]
+    public Transform consumableContainer;
+    public Transform weaponContainer;
+
+    [Header("Prefabs")]
+    public GameObject inventoryButtonPrefab;
+
+    [Header("Equipment Slots")]
+    public WeaponSlotUI leftHandSlot;
+    public WeaponSlotUI rightHandSlot;
+
+    private void Awake()
+    {
+        if (player == null)
+            player = FindObjectOfType<Player>();
+        if (battleManager == null)
+            battleManager = FindObjectOfType<BattleManager>();
+    }
+
+    private void Start()
+    {
+        RefreshUI();
+    }
+
+    /// <summary>
+    /// Rebuilds the inventory list and updates equipped weapon icons.
+    /// </summary>
+    public void RefreshUI()
+    {
+        if (player == null) return;
+
+        // Clear existing children
+        if (consumableContainer != null)
+        {
+            foreach (Transform child in consumableContainer)
+                Destroy(child.gameObject);
+        }
+        if (weaponContainer != null)
+        {
+            foreach (Transform child in weaponContainer)
+                Destroy(child.gameObject);
+        }
+
+        // Populate inventory
+        foreach (var item in new List<Item>(player.inventoryItems))
+        {
+            if (item is ConsumeTurnItem)
+            {
+                CreateConsumableEntry(item as ConsumeTurnItem);
+            }
+            else if (item is Weapon weapon)
+            {
+                CreateWeaponEntry(weapon);
+            }
+        }
+
+        // Update equipped weapon slots
+        leftHandSlot?.SetWeapon(player.leftHandWeapon);
+        rightHandSlot?.SetWeapon(player.rightHandWeapon);
+    }
+
+    private void CreateConsumableEntry(ConsumeTurnItem item)
+    {
+        if (consumableContainer == null || inventoryButtonPrefab == null || battleManager == null) return;
+
+        GameObject obj = Instantiate(inventoryButtonPrefab, consumableContainer);
+        var image = obj.GetComponent<Image>();
+        if (image != null && item.icon != null)
+            image.sprite = item.icon;
+
+        var button = obj.GetComponent<ItemButtonUI>();
+        if (button == null)
+            button = obj.AddComponent<ItemButtonUI>();
+        button.item = item;
+        button.battleManager = battleManager;
+    }
+
+    private void CreateWeaponEntry(Weapon weapon)
+    {
+        if (weaponContainer == null || inventoryButtonPrefab == null) return;
+
+        GameObject obj = Instantiate(inventoryButtonPrefab, weaponContainer);
+        var image = obj.GetComponent<Image>();
+        if (image != null && weapon.icon != null)
+            image.sprite = weapon.icon;
+
+        // Ensure canvas group for dragging
+        if (obj.GetComponent<CanvasGroup>() == null)
+            obj.AddComponent<CanvasGroup>();
+
+        var drag = obj.GetComponent<WeaponDragHandler>();
+        if (drag == null)
+            drag = obj.AddComponent<WeaponDragHandler>();
+        drag.weapon = weapon;
+    }
+}
+

--- a/LlmGame/Assets/Script/UI/BattleInventoryUI.cs.meta
+++ b/LlmGame/Assets/Script/UI/BattleInventoryUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e1f1e8a87d8043a6a6fb678c0a8a3764
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/LlmGame/Assets/Script/UI/WeaponDragHandler.cs
+++ b/LlmGame/Assets/Script/UI/WeaponDragHandler.cs
@@ -1,0 +1,50 @@
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+public class WeaponDragHandler : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDragHandler
+{
+    public Weapon weapon;
+
+    private Transform originalParent;
+    private CanvasGroup canvasGroup;
+    private Canvas rootCanvas;
+    private bool equipped = false;
+
+    private void Awake()
+    {
+        canvasGroup = GetComponent<CanvasGroup>();
+        rootCanvas = GetComponentInParent<Canvas>();
+    }
+
+    public void OnBeginDrag(PointerEventData eventData)
+    {
+        equipped = false;
+        originalParent = transform.parent;
+        if (rootCanvas != null)
+            transform.SetParent(rootCanvas.transform);
+        canvasGroup.blocksRaycasts = false;
+    }
+
+    public void OnDrag(PointerEventData eventData)
+    {
+        transform.position = eventData.position;
+    }
+
+    public void OnEndDrag(PointerEventData eventData)
+    {
+        canvasGroup.blocksRaycasts = true;
+        if (!equipped)
+        {
+            transform.SetParent(originalParent);
+        }
+        else
+        {
+            Destroy(gameObject);
+        }
+    }
+
+    public void MarkEquipped()
+    {
+        equipped = true;
+    }
+}

--- a/LlmGame/Assets/Script/UI/WeaponDragHandler.cs.meta
+++ b/LlmGame/Assets/Script/UI/WeaponDragHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6ab6657715db4f5891fdf63b13dd40e5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/LlmGame/Assets/Script/UI/WeaponSlotUI.cs
+++ b/LlmGame/Assets/Script/UI/WeaponSlotUI.cs
@@ -1,0 +1,77 @@
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+public class WeaponSlotUI : MonoBehaviour, IDropHandler
+{
+    [Header("Slot Settings")]
+    public bool isRightHand;
+    public Image slotImage;
+
+    private Player player;
+    private BattleManager battleManager;
+    private BattleInventoryUI inventoryUI;
+
+    private void Awake()
+    {
+        if (slotImage == null)
+            slotImage = GetComponent<Image>();
+        player = FindObjectOfType<Player>();
+        battleManager = FindObjectOfType<BattleManager>();
+        inventoryUI = FindObjectOfType<BattleInventoryUI>();
+    }
+
+    public void SetWeapon(Weapon weapon)
+    {
+        if (slotImage == null) return;
+        if (weapon != null && weapon.icon != null)
+        {
+            slotImage.sprite = weapon.icon;
+            slotImage.enabled = true;
+        }
+        else
+        {
+            slotImage.sprite = null;
+            slotImage.enabled = false;
+        }
+    }
+
+    public void OnDrop(PointerEventData eventData)
+    {
+        var drag = eventData.pointerDrag ? eventData.pointerDrag.GetComponent<WeaponDragHandler>() : null;
+        if (drag == null) return;
+
+        Weapon weapon = drag.weapon;
+        if (weapon == null || player == null) return;
+
+        // Only allow equipping during the player's action phase
+        if (battleManager != null && (!battleManager.isActionPhase || battleManager.currentActingCharacter != player))
+            return;
+
+        // Store previous weapons to return to inventory
+        Weapon oldLeft = player.leftHandWeapon;
+        Weapon oldRight = player.rightHandWeapon;
+
+        if (player.EquipWeapon(weapon, isRightHand))
+        {
+            // Remove equipped weapon from inventory
+            player.inventoryItems.Remove(weapon);
+
+            // Return previous weapons to inventory if they are no longer equipped
+            if (oldLeft != null && oldLeft != player.leftHandWeapon && oldLeft != player.rightHandWeapon)
+            {
+                if (!player.inventoryItems.Contains(oldLeft))
+                    player.inventoryItems.Add(oldLeft);
+            }
+            if (oldRight != null && oldRight != player.leftHandWeapon && oldRight != player.rightHandWeapon && oldRight != oldLeft)
+            {
+                if (!player.inventoryItems.Contains(oldRight))
+                    player.inventoryItems.Add(oldRight);
+            }
+
+            drag.MarkEquipped();
+            inventoryUI?.RefreshUI();
+            battleManager?.EndPlayerTurn();
+        }
+    }
+}

--- a/LlmGame/Assets/Script/UI/WeaponSlotUI.cs.meta
+++ b/LlmGame/Assets/Script/UI/WeaponSlotUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9e099f2b1e3b45e48981bf8e4a73eefe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add battle inventory UI to list consumables and weapons
- support dragging weapons into left/right equipment slots
- refresh inventory visuals when the player's turn ends

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689dac0f4d648322b57dc4d7fe3e5650