### PR TITLE
refactor: consolidate weapon handling into single slot

### DIFF
--- a/LlmGame/Assets/ObjCharacter/PlayerData.prefab
+++ b/LlmGame/Assets/ObjCharacter/PlayerData.prefab
@@ -59,8 +59,7 @@ MonoBehaviour:
   money: 0
   inventoryItems: []
   inventoryArmors: []
-  leftHandWeapon: {fileID: 0}
-  rightHandWeapon: {fileID: 0}
+  equippedWeapon: {fileID: 0}
   equippedPassiveItems:
   - {fileID: 11400000, guid: 73640516f0c1c3141abd11bcce742a26, type: 2}
   - {fileID: 11400000, guid: 04fc71bbf6c3a6e4aabaf39be483b8e5, type: 2}

--- a/LlmGame/Assets/Prefabs/Character/Enemy/Zhuyi easy.prefab
+++ b/LlmGame/Assets/Prefabs/Character/Enemy/Zhuyi easy.prefab
@@ -219,8 +219,7 @@ MonoBehaviour:
   inventoryItems:
   - {fileID: 11400000, guid: fb8463efd121cab4f93f12fbd78eb461, type: 2}
   inventoryArmors: []
-  leftHandWeapon: {fileID: 0}
-  rightHandWeapon: {fileID: 11400000, guid: 5eb97eab966aeda4d8df1114c3fcc71e, type: 2}
+  equippedWeapon: {fileID: 11400000, guid: 5eb97eab966aeda4d8df1114c3fcc71e, type: 2}
   activeItem: []
   isUsingConsumeTurnItem: 0
   archetype: 0

--- a/LlmGame/Assets/Prefabs/Character/Player/Houyi MC.prefab
+++ b/LlmGame/Assets/Prefabs/Character/Player/Houyi MC.prefab
@@ -624,8 +624,7 @@ MonoBehaviour:
   turnGauge: 0
   inventoryItems: []
   inventoryArmors: []
-  leftHandWeapon: {fileID: 0}
-  rightHandWeapon: {fileID: 0}
+  equippedWeapon: {fileID: 0}
   activeItem: []
   isUsingConsumeTurnItem: 0
 --- !u!114 &7262446337314057770

--- a/LlmGame/Assets/Script/BattleManager.cs
+++ b/LlmGame/Assets/Script/BattleManager.cs
@@ -353,8 +353,7 @@ public class BattleManager : MonoBehaviour
             item.isActive = false;
 
         // ✅ Weapon activation
-        ProcessWeaponForActivation(enemy.leftHandWeapon, lowerAction, enemy);
-        ProcessWeaponForActivation(enemy.rightHandWeapon, lowerAction, enemy);
+        ProcessWeaponForActivation(enemy.equippedWeapon, lowerAction, enemy);
 
         // ✅ Optional: Activate items based on keywords
         foreach (var item in enemy.activeItem)

--- a/LlmGame/Assets/Script/Character.cs
+++ b/LlmGame/Assets/Script/Character.cs
@@ -73,8 +73,8 @@ public class Character : MonoBehaviour
     [SerializeField] public List<ArmorData> inventoryArmors;
 
     [Header("Equipment")]
-    public Weapon leftHandWeapon;
-    public Weapon rightHandWeapon;
+    // Characters now use a single weapon slot instead of separate left/right hands
+    public Weapon equippedWeapon;
     [SerializeField] public Dictionary<BodyPartType, ArmorData> equippedArmorByPart = new();
 
     [Header("Active Items")]
@@ -660,54 +660,18 @@ public class Character : MonoBehaviour
 
     #region  Equipment
 
-    public bool EquipWeapon(Weapon weapon, bool isRightHand)
+    public bool EquipWeapon(Weapon weapon)
     {
         if (weapon == null) return false;
 
-        if (weapon.isTwoHandWeapon)
-        {
-            // Two-handed weapons occupy both hands
-            leftHandWeapon = weapon;
-            rightHandWeapon = weapon;
-        }
-        else
-        {
-            // Equip normally
-            if (isRightHand)
-                rightHandWeapon = weapon;
-            else
-                leftHandWeapon = weapon;
-
-            // Unequip two-hand if one-handed weapon is equipped
-            if (leftHandWeapon != rightHandWeapon)
-            {
-                if (leftHandWeapon?.isTwoHandWeapon == true)
-                    leftHandWeapon = null;
-
-                if (rightHandWeapon?.isTwoHandWeapon == true)
-                    rightHandWeapon = null;
-            }
-        }
-
+        // Single equipment slot – simply replace whatever was previously equipped
+        equippedWeapon = weapon;
         return true;
     }
 
-    public void UnequipRightHand()
+    public void UnequipWeapon()
     {
-        rightHandWeapon = null;
-
-        // If it's a two-handed weapon, remove both
-        if (leftHandWeapon?.isTwoHandWeapon == true)
-            leftHandWeapon = null;
-    }
-
-    public void UnequipLeftHand()
-    {
-        leftHandWeapon = null;
-
-        // If it's a two-handed weapon, remove both
-        if (rightHandWeapon?.isTwoHandWeapon == true)
-            rightHandWeapon = null;
+        equippedWeapon = null;
     }
 
     #endregion

--- a/LlmGame/Assets/Script/DamageCalculator.cs
+++ b/LlmGame/Assets/Script/DamageCalculator.cs
@@ -157,7 +157,7 @@ public class DamageCalculator : MonoBehaviour
 
         // 🔍 Check for Ghostscope Overlay (ignore feasibility/potential reduction with ranged weapons)
         bool ignoreArmorPenalty = false;
-        Weapon activeWeapon = attacker is Player ap ? ap.rightHandWeapon ?? ap.leftHandWeapon : null;
+        Weapon activeWeapon = attacker is Player ap ? ap.equippedWeapon : null;
         if (activeWeapon != null && activeWeapon.weaponType == WeaponType.Ranged_Weapon)
         {
             foreach (var part in attacker.bodyParts)
@@ -239,7 +239,7 @@ public class DamageCalculator : MonoBehaviour
         if (target.currentshield <= 0)
         {
             float splitDamage = scaledFinalDamage / selectedTargetParts.Count;
-            Weapon usedWeapon = attacker is Player player ? player.rightHandWeapon : null;
+            Weapon usedWeapon = attacker is Player player ? player.equippedWeapon : null;
 
             foreach (var part in selectedTargetParts)
             {
@@ -362,7 +362,7 @@ public class DamageCalculator : MonoBehaviour
         float finalPotential = Mathf.Max(0f, potential + potentialModifierSum);
 
         bool ignoreArmorPenalty = false;
-        Weapon activeWeapon = attacker is Player ap ? ap.rightHandWeapon ?? ap.leftHandWeapon : null;
+        Weapon activeWeapon = attacker is Player ap ? ap.equippedWeapon : null;
         if (activeWeapon != null && activeWeapon.weaponType == WeaponType.Ranged_Weapon)
         {
             foreach (var part in attacker.bodyParts)
@@ -442,7 +442,7 @@ public class DamageCalculator : MonoBehaviour
         if (target.currentshield <= 0)
         {
             float damagePerPart = scaledFinalDamage / selectedTargetParts.Count;
-            Weapon weapon = attacker is Player player ? player.rightHandWeapon : null;
+            Weapon weapon = attacker is Player player ? player.equippedWeapon : null;
 
             if (attacker.currentSkill != null && attacker.currentSkill.isDamagePercentagePart)
             {

--- a/LlmGame/Assets/Script/DefaultPlayerConfig.cs
+++ b/LlmGame/Assets/Script/DefaultPlayerConfig.cs
@@ -22,8 +22,8 @@ public class DefaultPlayerConfig : ScriptableObject
     [Header("Starting Inventory & Equipment")]
     public List<Item> startingInventory = new List<Item>();
 
-    public Weapon leftHandWeapon;
-    public Weapon rightHandWeapon;
+    // Single starting weapon
+    public Weapon startingWeapon;
 
     public List<PassiveItemData> startingPassives = new List<PassiveItemData>();
 

--- a/LlmGame/Assets/Script/InputKeywordHighlighter.cs
+++ b/LlmGame/Assets/Script/InputKeywordHighlighter.cs
@@ -32,12 +32,8 @@ public class InputKeywordHighlighter : MonoBehaviour
             return;
         }
 
-        // ✅ Add Main_Weapon keywords from equipped weapons
-        AddWeaponKeywords(battleManager.player.leftHandWeapon, ItemType.Main_Weapon);
-        if (battleManager.player.rightHandWeapon != battleManager.player.leftHandWeapon)
-        {
-            AddWeaponKeywords(battleManager.player.rightHandWeapon, ItemType.Main_Weapon);
-        }
+        // ✅ Add Main_Weapon keywords from equipped weapon
+        AddWeaponKeywords(battleManager.player.equippedWeapon, ItemType.Main_Weapon);
 
         // ✅ Add Sub_Weapon keywords from inventory
         foreach (var item in battleManager.player.inventoryItems)

--- a/LlmGame/Assets/Script/Item/BiohazardReactor.cs
+++ b/LlmGame/Assets/Script/Item/BiohazardReactor.cs
@@ -42,7 +42,7 @@ public class BiohazardReactor : MonoBehaviour, IPassiveItem, IDamageReaction
     {
         if (source == null || target == null) return;
 
-        Weapon weapon = source.rightHandWeapon ?? source.leftHandWeapon;
+        Weapon weapon = source.equippedWeapon;
 
         if (weapon == null || weapon.weaponType != WeaponType.Melee_Weapon) return;
 

--- a/LlmGame/Assets/Script/Item/CombatGrips.cs
+++ b/LlmGame/Assets/Script/Item/CombatGrips.cs
@@ -10,7 +10,7 @@ public class CombatGrips : MonoBehaviour, IPassiveItem
 
     public void ApplyEffect(Character character)
     {
-        Weapon weapon = character.rightHandWeapon;
+        Weapon weapon = character.equippedWeapon;
 
         if (weapon != null && weapon.weaponType == WeaponType.Melee_Weapon)
         {

--- a/LlmGame/Assets/Script/Item/CombatHUDProcessor.cs
+++ b/LlmGame/Assets/Script/Item/CombatHUDProcessor.cs
@@ -34,7 +34,7 @@ public class CombatHUDProcessor : MonoBehaviour, IPassiveItem, ITurnListener, ID
         if (usedThisTurn || source != owner || target == null)
             return;
 
-        Weapon weapon = owner.rightHandWeapon ?? owner.leftHandWeapon;
+        Weapon weapon = owner.equippedWeapon;
         if (weapon != null && weapon.weaponType == WeaponType.Ranged_Weapon)
         {
             target.TakeDamage(bonusDamage);

--- a/LlmGame/Assets/Script/Item/HawkEyeLens.cs
+++ b/LlmGame/Assets/Script/Item/HawkEyeLens.cs
@@ -8,7 +8,7 @@ public class HawkEyeLens : MonoBehaviour, IPassiveItem
     {
         if (character is Player player)
         {
-            Weapon weapon = player.rightHandWeapon ?? player.leftHandWeapon;
+            Weapon weapon = player.equippedWeapon;
             if (weapon != null && weapon.weaponType == WeaponType.Ranged_Weapon)
             {
                 player.possibilityPool.AddModifier(StatusChanceType.Critical, critBonus);

--- a/LlmGame/Assets/Script/Item/InjectorGauntlets.cs
+++ b/LlmGame/Assets/Script/Item/InjectorGauntlets.cs
@@ -17,7 +17,7 @@ public class InjectorGauntlets : MonoBehaviour, IPassiveItem, IDamageReaction
     {
         if (source == null || target == null) return;
 
-        Weapon weapon = source.rightHandWeapon ?? source.leftHandWeapon;
+        Weapon weapon = source.equippedWeapon;
         if (weapon == null || weapon.weaponType != WeaponType.Melee_Weapon) return;
 
         if (Random.value <= STATUS_CHANCE)

--- a/LlmGame/Assets/Script/Item/RangedWeaponFocus.cs
+++ b/LlmGame/Assets/Script/Item/RangedWeaponFocus.cs
@@ -12,7 +12,7 @@ public class RangedWeaponFocus : MonoBehaviour, IPassiveItem
         // Ensure it's a Player character
         if (character is Player player)
         {
-            Weapon weapon = player.rightHandWeapon ?? player.leftHandWeapon;
+            Weapon weapon = player.equippedWeapon;
 
             if (weapon != null && weapon.weaponType == WeaponType.Ranged_Weapon)
             {

--- a/LlmGame/Assets/Script/Item/RecoilStabilizerArmor.cs
+++ b/LlmGame/Assets/Script/Item/RecoilStabilizerArmor.cs
@@ -23,7 +23,7 @@ public class RecoilStabilizerArmor : MonoBehaviour, IPassiveItem, IDamageReactio
     private Weapon GetWeapon()
     {
         if (owner is Player p)
-            return p.rightHandWeapon ?? p.leftHandWeapon;
+            return p.equippedWeapon;
         return null;
     }
 

--- a/LlmGame/Assets/Script/Item/StabilizerGloves.cs
+++ b/LlmGame/Assets/Script/Item/StabilizerGloves.cs
@@ -19,7 +19,7 @@ public class StabilizerGloves : MonoBehaviour, IPassiveItem, IDamageReaction
     public void OnBeforeDamage(Character source, Character target, ref int damage)
     {
         if (source != owner) return;
-        Weapon weapon = owner.rightHandWeapon ?? owner.leftHandWeapon;
+        Weapon weapon = owner.equippedWeapon;
         if (weapon != null && weapon.weaponType == WeaponType.Ranged_Weapon)
         {
             damage += damageBonus;

--- a/LlmGame/Assets/Script/Item/TacticalVisor.cs
+++ b/LlmGame/Assets/Script/Item/TacticalVisor.cs
@@ -10,7 +10,7 @@ public class TacticalVisor : MonoBehaviour, IPassiveItem
     public void ApplyEffect(Character character)
     {
         // Only apply if using a ranged weapon
-        if (character.rightHandWeapon != null && character.rightHandWeapon.weaponType == WeaponType.Ranged_Weapon)
+        if (character.equippedWeapon != null && character.equippedWeapon.weaponType == WeaponType.Ranged_Weapon)
         {
             character.attack += bonusRangedDamage;
             character.bonusAttack += bonusRangedDamage;

--- a/LlmGame/Assets/Script/PlayerData.cs
+++ b/LlmGame/Assets/Script/PlayerData.cs
@@ -25,8 +25,7 @@ public class PlayerData : MonoBehaviour
     // Inventory and equipment
     public List<Item> inventoryItems = new List<Item>();
     public List<ArmorData> inventoryArmors = new List<ArmorData>();
-    public Weapon leftHandWeapon;
-    public Weapon rightHandWeapon;
+    public Weapon equippedWeapon;
     public List<PassiveItemData> equippedPassiveItems = new List<PassiveItemData>();
 
     // Tracks which passive item effects have already been applied to avoid stacking
@@ -77,8 +76,7 @@ public class PlayerData : MonoBehaviour
         // Inventory / equipment
         inventoryItems = config ? new List<Item>(config.startingInventory) : new List<Item>();
         inventoryArmors = config ? new List<ArmorData>(config.startingArmors) : new List<ArmorData>(); // ✅ Properly load starting armor
-        leftHandWeapon = config ? config.leftHandWeapon : null;
-        rightHandWeapon = config ? config.rightHandWeapon : null;
+        equippedWeapon = config ? config.startingWeapon : null;
         equippedPassiveItems = config ? new List<PassiveItemData>(config.startingPassives) : new List<PassiveItemData>();
 
         equippedArmors = new List<EquippedArmorEntry>(); // remains empty unless equipped manually
@@ -112,8 +110,7 @@ public class PlayerData : MonoBehaviour
 
         inventoryItems = new List<Item>(player.inventoryItems);
         inventoryArmors = new List<ArmorData>(player.inventoryArmors);
-        leftHandWeapon = player.leftHandWeapon;
-        rightHandWeapon = player.rightHandWeapon;
+        equippedWeapon = player.equippedWeapon;
 
         // Save equipped armors from body parts
         equippedArmors = new List<EquippedArmorEntry>();
@@ -171,8 +168,7 @@ public class PlayerData : MonoBehaviour
 
         player.inventoryItems = new List<Item>(inventoryItems);
         player.inventoryArmors = new List<ArmorData>(inventoryArmors);
-        player.leftHandWeapon = leftHandWeapon;
-        player.rightHandWeapon = rightHandWeapon;
+        player.equippedWeapon = equippedWeapon;
 
         // Load equipped armor into body parts and runtime map
         player.equippedArmorByPart = new Dictionary<BodyPartType, ArmorData>();

--- a/LlmGame/Assets/Script/PromptBuilder.cs
+++ b/LlmGame/Assets/Script/PromptBuilder.cs
@@ -239,11 +239,8 @@ public static class PromptBuilder
         // Prepare items to check: equipped weapons + Sub_Weapons in inventory
         List<Item> itemsToCheck = new List<Item>();
 
-        if (battleManager.player.leftHandWeapon != null)
-            itemsToCheck.Add(battleManager.player.leftHandWeapon);
-
-        if (battleManager.player.rightHandWeapon != null)
-            itemsToCheck.Add(battleManager.player.rightHandWeapon);
+        if (battleManager.player.equippedWeapon != null)
+            itemsToCheck.Add(battleManager.player.equippedWeapon);
 
         foreach (var item in battleManager.player.inventoryItems)
         {

--- a/LlmGame/Assets/Script/UI/BattleInventoryUI.cs
+++ b/LlmGame/Assets/Script/UI/BattleInventoryUI.cs
@@ -16,8 +16,8 @@ public class BattleInventoryUI : MonoBehaviour
     public GameObject inventoryButtonPrefab;
 
     [Header("Equipment Slots")]
-    public WeaponSlotUI leftHandSlot;
-    public WeaponSlotUI rightHandSlot;
+    // UI now exposes a single weapon slot
+    public WeaponSlotUI weaponSlot;
 
     private void Awake()
     {
@@ -65,8 +65,7 @@ public class BattleInventoryUI : MonoBehaviour
         }
 
         // Update equipped weapon slots
-        leftHandSlot?.SetWeapon(player.leftHandWeapon);
-        rightHandSlot?.SetWeapon(player.rightHandWeapon);
+        weaponSlot?.SetWeapon(player.equippedWeapon);
     }
 
     private void CreateConsumableEntry(ConsumeTurnItem item)

--- a/LlmGame/Assets/Script/UI/WeaponSlotUI.cs
+++ b/LlmGame/Assets/Script/UI/WeaponSlotUI.cs
@@ -5,7 +5,6 @@ using UnityEngine.EventSystems;
 public class WeaponSlotUI : MonoBehaviour, IDropHandler, IPointerEnterHandler, IPointerExitHandler
 {
     [Header("Slot Settings")]
-    public bool isRightHand;
     public Image slotImage;
 
     [Header("Tooltip")]
@@ -15,9 +14,8 @@ public class WeaponSlotUI : MonoBehaviour, IDropHandler, IPointerEnterHandler, I
     private BattleManager battleManager;
     private BattleInventoryUI inventoryUI;
 
-    [Header("Empty Slot Icons")]
-    public Sprite emptyLeftHandIcon;
-    public Sprite emptyRightHandIcon;
+    [Header("Empty Slot Icon")]
+    public Sprite emptySlotIcon;
 
     private void Awake()
     {
@@ -43,7 +41,7 @@ public class WeaponSlotUI : MonoBehaviour, IDropHandler, IPointerEnterHandler, I
         }
         else
         {
-            slotImage.sprite = isRightHand ? emptyRightHandIcon : emptyLeftHandIcon;
+            slotImage.sprite = emptySlotIcon;
             slotImage.enabled = true;
         }
     }
@@ -59,23 +57,16 @@ public class WeaponSlotUI : MonoBehaviour, IDropHandler, IPointerEnterHandler, I
         if (battleManager != null && (!battleManager.isActionPhase || battleManager.currentActingCharacter != player))
             return;
 
-        Weapon oldLeft = player.leftHandWeapon;
-        Weapon oldRight = player.rightHandWeapon;
+        Weapon oldWeapon = player.equippedWeapon;
 
-        if (player.EquipWeapon(weapon, isRightHand))
+        if (player.EquipWeapon(weapon))
         {
             player.inventoryItems.Remove(weapon);
 
-            if (oldLeft != null && oldLeft != player.leftHandWeapon && oldLeft != player.rightHandWeapon)
+            if (oldWeapon != null && oldWeapon != player.equippedWeapon)
             {
-                if (!player.inventoryItems.Contains(oldLeft))
-                    player.inventoryItems.Add(oldLeft);
-            }
-
-            if (oldRight != null && oldRight != player.leftHandWeapon && oldRight != player.rightHandWeapon && oldRight != oldLeft)
-            {
-                if (!player.inventoryItems.Contains(oldRight))
-                    player.inventoryItems.Add(oldRight);
+                if (!player.inventoryItems.Contains(oldWeapon))
+                    player.inventoryItems.Add(oldWeapon);
             }
 
             drag.MarkEquipped();
@@ -87,7 +78,7 @@ public class WeaponSlotUI : MonoBehaviour, IDropHandler, IPointerEnterHandler, I
     // === Tooltip logic ===
     public void OnPointerEnter(PointerEventData eventData)
     {
-        Weapon equippedWeapon = isRightHand ? player?.rightHandWeapon : player?.leftHandWeapon;
+        Weapon equippedWeapon = player?.equippedWeapon;
 
         if (equippedWeapon != null && tooltip != null)
         {


### PR DESCRIPTION
## Summary
- collapse dual-wield logic into a single `equippedWeapon` field
- adjust UI and data configs for one weapon slot
- update combat and item effects to reference the unified weapon

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2a1f71ffc832280ae35bc9f9e7267