### PR TITLE
Add status effect UI with icons and tooltips

### DIFF
--- a/LlmGame/Assets/Script/Character.cs
+++ b/LlmGame/Assets/Script/Character.cs
@@ -51,6 +51,7 @@ public class Character : MonoBehaviour
 
     [Header("Status Effects")]
     [SerializeField] public List<TurnStatusEffect> activeStatusEffects = new List<TurnStatusEffect>();
+    public event Action StatusEffectsChanged;
 
     [Header("Critical")]
     public bool isCritical;
@@ -351,6 +352,8 @@ public class Character : MonoBehaviour
             activeStatusEffects.Add(contam);
             Debug.Log($"{characterName} becomes CONTAMINATED.");
         }
+
+        StatusEffectsChanged?.Invoke();
     }
 
 
@@ -582,6 +585,8 @@ public class Character : MonoBehaviour
         {
             activeStatusEffects.Remove(contam);
         }
+
+        StatusEffectsChanged?.Invoke();
     }
 
     private void TryApplyNerveRotVialDebuff(Character source)

--- a/LlmGame/Assets/Script/UI/CharacterStatusUI.cs
+++ b/LlmGame/Assets/Script/UI/CharacterStatusUI.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Handles displaying all active status effect icons for a character.
+/// </summary>
+public class CharacterStatusUI : MonoBehaviour
+{
+    public Character character;
+    public RectTransform iconContainer;
+    public StatusEffectIconUI iconPrefab;
+    public StatusEffectTooltip tooltip;
+
+    private readonly Dictionary<StatusEffectType, StatusEffectIconUI> activeIcons = new();
+
+    private void Awake()
+    {
+        if (character == null)
+            character = GetComponent<Character>();
+
+        if (character != null)
+            character.StatusEffectsChanged += Refresh;
+    }
+
+    private void Start()
+    {
+        Refresh();
+    }
+
+    private void OnDestroy()
+    {
+        if (character != null)
+            character.StatusEffectsChanged -= Refresh;
+    }
+
+    /// <summary>Refreshes the icon list to match the character's active effects.</summary>
+    public void Refresh()
+    {
+        if (character == null || iconContainer == null || iconPrefab == null) return;
+
+        // Remove icons for missing effects
+        var toRemove = new List<StatusEffectType>();
+        foreach (var kv in activeIcons)
+        {
+            if (!character.activeStatusEffects.Exists(e => e.effectType == kv.Key))
+            {
+                Destroy(kv.Value.gameObject);
+                toRemove.Add(kv.Key);
+            }
+        }
+        foreach (var type in toRemove) activeIcons.Remove(type);
+
+        // Add or update icons
+        foreach (var effect in character.activeStatusEffects)
+        {
+            if (activeIcons.TryGetValue(effect.effectType, out var icon))
+            {
+                icon.UpdateData(effect);
+            }
+            else
+            {
+                var newIcon = Instantiate(iconPrefab, iconContainer);
+                newIcon.Initialize(effect, tooltip);
+                activeIcons.Add(effect.effectType, newIcon);
+            }
+        }
+    }
+}
+

--- a/LlmGame/Assets/Script/UI/StatusEffectIconUI.cs
+++ b/LlmGame/Assets/Script/UI/StatusEffectIconUI.cs
@@ -1,0 +1,47 @@
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+/// <summary>
+/// Represents a single status effect icon in the UI. Handles animation and tooltip display.
+/// </summary>
+public class StatusEffectIconUI : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler
+{
+    public Image iconImage;
+    public Animator animator;
+    private TurnStatusEffect effect;
+    private StatusEffectTooltip tooltip;
+
+    /// <summary>Initialize this icon with a status effect and tooltip reference.</summary>
+    public void Initialize(TurnStatusEffect status, StatusEffectTooltip tooltipUI)
+    {
+        effect = status;
+        tooltip = tooltipUI;
+        UpdateVisual();
+        animator?.SetTrigger("Activate");
+    }
+
+    /// <summary>Update the underlying effect (e.g., remaining turns).</summary>
+    public void UpdateData(TurnStatusEffect status)
+    {
+        effect = status;
+        UpdateVisual();
+    }
+
+    private void UpdateVisual()
+    {
+        if (iconImage != null)
+            iconImage.sprite = StatusEffectInfo.GetIcon(effect.effectType);
+    }
+
+    public void OnPointerEnter(PointerEventData eventData)
+    {
+        tooltip?.Show(effect.effectType, StatusEffectInfo.GetDescription(effect.effectType), iconImage?.sprite, transform as RectTransform);
+    }
+
+    public void OnPointerExit(PointerEventData eventData)
+    {
+        tooltip?.HideTooltip();
+    }
+}
+

--- a/LlmGame/Assets/Script/UI/StatusEffectInfo.cs
+++ b/LlmGame/Assets/Script/UI/StatusEffectInfo.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Helper database providing icon and description data for each <see cref="StatusEffectType"/>.
+/// Icons are loaded from Resources/StatusEffects/{EffectType}.png by default.
+/// </summary>
+public static class StatusEffectInfo
+{
+    private static readonly Dictionary<StatusEffectType, string> descriptions = new()
+    {
+        { StatusEffectType.Stun, "Unable to act during their next turn." },
+        { StatusEffectType.DefenseDown, "Defense is reduced." },
+        { StatusEffectType.AttackDown, "Attack power is reduced." },
+        { StatusEffectType.FocusDown, "Focus is reduced." },
+        { StatusEffectType.Bleed, "Loses HP each turn." },
+        { StatusEffectType.Poison, "Takes poison damage over time." },
+        { StatusEffectType.Radiation, "Radiated - may trigger additional effects." },
+        { StatusEffectType.Contaminated, "Suffers combined poison and radiation effects." },
+        { StatusEffectType.AttackUp, "Attack power is increased." },
+        { StatusEffectType.DefenseUp, "Defense is increased." },
+        { StatusEffectType.SpeedUp, "Speed is increased." },
+        { StatusEffectType.CritChanceUp, "Critical hit chance is increased." },
+        { StatusEffectType.CritDamageUp, "Critical hit damage is increased." },
+        { StatusEffectType.HealReduction, "Healing received is reduced." }
+    };
+
+    /// <summary>Returns a human readable description for the given effect.</summary>
+    public static string GetDescription(StatusEffectType type)
+        => descriptions.TryGetValue(type, out var desc) ? desc : string.Empty;
+
+    /// <summary>
+    /// Returns the sprite for the effect. Looks under Resources/StatusEffects/ using the enum name.
+    /// </summary>
+    public static Sprite GetIcon(StatusEffectType type)
+        => Resources.Load<Sprite>($"StatusEffects/{type}");
+}
+

--- a/LlmGame/Assets/Script/UI/StatusEffectTooltip.cs
+++ b/LlmGame/Assets/Script/UI/StatusEffectTooltip.cs
@@ -1,0 +1,48 @@
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Simple tooltip UI used to display details about a status effect.
+/// </summary>
+public class StatusEffectTooltip : MonoBehaviour
+{
+    public TMP_Text nameText;
+    public TMP_Text descriptionText;
+    public Image iconImage;
+
+    private void Awake()
+    {
+        HideTooltip();
+    }
+
+    /// <summary>Show the tooltip near the given target.</summary>
+    public void Show(StatusEffectType type, string description, Sprite icon, RectTransform target)
+    {
+        if (nameText != null)
+            nameText.text = type.ToString();
+
+        if (descriptionText != null)
+            descriptionText.text = description;
+
+        if (iconImage != null)
+            iconImage.sprite = icon;
+
+        gameObject.SetActive(true);
+        PositionTooltip(target);
+    }
+
+    public void HideTooltip()
+    {
+        gameObject.SetActive(false);
+    }
+
+    private void PositionTooltip(RectTransform target)
+    {
+        if (target == null) return;
+        RectTransform rect = transform as RectTransform;
+        Vector2 screenPoint = RectTransformUtility.WorldToScreenPoint(null, target.position);
+        rect.position = screenPoint;
+    }
+}
+


### PR DESCRIPTION
## Summary
- expose `StatusEffectsChanged` event on `Character` to notify UI when effects change
- add reusable database and tooltip components for status effects
- implement UI icons with animation and hover tooltips for each effect

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a539231adc832293307a0469d922dc