### PR TITLE
feat: weapon-based player animations

### DIFF
--- a/LlmGame/Assets/Script/BattleManager.cs
+++ b/LlmGame/Assets/Script/BattleManager.cs
@@ -491,7 +491,16 @@ public class BattleManager : MonoBehaviour
         }
 
         character.animationFinished = false;
-        character.animator.SetTrigger(animationTriggerName);
+
+        var weaponAnim = character.GetComponent<PlayerWeaponAnimation>();
+        if (weaponAnim != null && animationTriggerName == "Attack")
+        {
+            weaponAnim.PlayAttack();
+        }
+        else
+        {
+            character.animator.SetTrigger(animationTriggerName);
+        }
 
         float timeout = 3f;
         float timer = 0f;

--- a/LlmGame/Assets/Script/Character.cs
+++ b/LlmGame/Assets/Script/Character.cs
@@ -672,12 +672,16 @@ public class Character : MonoBehaviour
 
         // Single equipment slot – simply replace whatever was previously equipped
         equippedWeapon = weapon;
+
+        // Notify any weapon animation handler
+        GetComponent<PlayerWeaponAnimation>()?.OnWeaponEquipped(weapon);
         return true;
     }
 
     public void UnequipWeapon()
     {
         equippedWeapon = null;
+        GetComponent<PlayerWeaponAnimation>()?.OnWeaponEquipped(null);
     }
 
     #endregion

--- a/LlmGame/Assets/Script/PlayerWeaponAnimation.cs
+++ b/LlmGame/Assets/Script/PlayerWeaponAnimation.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Handles switching idle and attack animations based on the player's equipped weapon.
+/// Attack animations are chosen randomly from a set defined per weapon.
+/// </summary>
+[RequireComponent(typeof(Player))]
+public class PlayerWeaponAnimation : MonoBehaviour
+{
+    [System.Serializable]
+    public class WeaponAnimationSet
+    {
+        public string weaponName;               // Name from Weapon.itemName
+        public AnimationClip idleAnimation;     // Idle animation for this weapon
+        public AnimationClip[] attackAnimations; // Attack animations for this weapon
+    }
+
+    [SerializeField] private Animator animator;
+    [SerializeField] private AnimationClip baseIdleClip;    // Clip used for Idle in the base controller
+    [SerializeField] private AnimationClip baseAttackClip;  // Clip used for Attack in the base controller
+    [SerializeField] private List<WeaponAnimationSet> weaponAnimationSets = new();
+
+    private Dictionary<string, WeaponAnimationSet> lookup = new();
+    private AnimatorOverrideController overrideController;
+    private Player player;
+
+    private void Awake()
+    {
+        player = GetComponent<Player>();
+        if (animator == null)
+            animator = GetComponent<Animator>();
+
+        // Prepare override controller
+        overrideController = new AnimatorOverrideController(animator.runtimeAnimatorController);
+        animator.runtimeAnimatorController = overrideController;
+
+        foreach (var set in weaponAnimationSets)
+        {
+            if (!string.IsNullOrEmpty(set.weaponName) && !lookup.ContainsKey(set.weaponName))
+            {
+                lookup.Add(set.weaponName, set);
+            }
+        }
+    }
+
+    private void Start()
+    {
+        OnWeaponEquipped(player != null ? player.equippedWeapon : null);
+    }
+
+    /// <summary>
+    /// Call when the player's weapon changes to update idle animation.
+    /// </summary>
+    public void OnWeaponEquipped(Weapon weapon)
+    {
+        if (weapon == null)
+        {
+            if (baseIdleClip != null)
+                overrideController[baseIdleClip] = baseIdleClip; // revert to default
+            return;
+        }
+
+        if (lookup.TryGetValue(weapon.itemName, out var set))
+        {
+            if (set.idleAnimation != null && baseIdleClip != null)
+            {
+                overrideController[baseIdleClip] = set.idleAnimation;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Randomly selects an attack animation for the current weapon and triggers the Attack parameter.
+    /// </summary>
+    public void PlayAttack()
+    {
+        Weapon weapon = player != null ? player.equippedWeapon : null;
+        if (weapon != null && lookup.TryGetValue(weapon.itemName, out var set))
+        {
+            if (set.attackAnimations != null && set.attackAnimations.Length > 0 && baseAttackClip != null)
+            {
+                var clip = set.attackAnimations[Random.Range(0, set.attackAnimations.Length)];
+                overrideController[baseAttackClip] = clip;
+            }
+        }
+
+        animator.SetTrigger("Attack");
+    }
+}


### PR DESCRIPTION
## Summary
- add PlayerWeaponAnimation to drive idle/attack clips per equipped weapon
- notify animation handler on weapon change and play random attack clips
- have BattleManager use PlayerWeaponAnimation when triggering attacks

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8231755d483229ba4c58e93316b62