### PR TITLE
Enable enemy status effects and add delayed action prompt

### DIFF
--- a/LlmGame/Assets/Script/BattleManager.cs
+++ b/LlmGame/Assets/Script/BattleManager.cs
@@ -4,7 +4,6 @@ using UnityEngine;
 using System.Text;
 using System.Linq;
 using TMPro;
-using System.Text.RegularExpressions; // Make sure this is at the top
 using Map;
 using UnityEngine.SceneManagement;
 
@@ -208,11 +207,12 @@ public class BattleManager : MonoBehaviour
                 yield break;
             }
 
-            // ✅ Check if enemy should use a consumable instead of attack
-            if (CheckAndActivateEnemyItems(enemy, enemy.selectedAction.actionName, out IEnumerator consumeRoutine))
+            // ✅ Automatically activate the enemy's equipped weapon
+            enemy.activeItem.Clear();
+            if (enemy.equippedWeapon != null)
             {
-                yield return StartCoroutine(consumeRoutine); // ✅ Use consumable
-                yield break; // ✅ End turn, skip attack
+                enemy.equippedWeapon.isActive = true;
+                enemy.activeItem.Add(enemy.equippedWeapon);
             }
 
             // 🎯 Perform normal attack
@@ -339,91 +339,6 @@ public class BattleManager : MonoBehaviour
 
         int randomIndex = Random.Range(0, enemy.actions.Count);
         return enemy.actions[randomIndex];
-    }
-
-    private bool CheckAndActivateEnemyItems(Enemy enemy, string enemyAction, out IEnumerator consumeRoutine)
-    {
-        string lowerAction = enemyAction.ToLower();
-
-        enemy.activeItem.Clear();
-        consumeRoutine = null;
-
-        // 🔁 Reset activation states
-        foreach (var item in enemy.inventoryItems)
-            item.isActive = false;
-
-        // ✅ Weapon activation
-        ProcessWeaponForActivation(enemy.equippedWeapon, lowerAction, enemy);
-
-        // ✅ Optional: Activate items based on keywords
-        foreach (var item in enemy.activeItem)
-        {
-            if (item == null || item.keyWords == null) continue;
-
-            if (item is ConsumeTurnItem consumeItem)
-            {
-                foreach (string keyword in item.keyWords)
-                {
-                    string lowerKeyword = keyword.ToLower();
-
-                    Character healTarget = enemy;
-                    item.isActive = true;
-                    enemy.activeItem.Add(item);
-
-                    enemy.isUsingConsumeTurnItem = true;
-
-                    if (healTarget != null)
-                    {
-                        Debug.Log($"Enemy {enemy.characterName} will use {consumeItem.itemName} on {healTarget.characterName}");
-                        consumeRoutine = consumeItem.UseOnTarget(enemy, healTarget, this);
-                        return true;
-                    }
-                    else
-                    {
-                        Debug.LogWarning("No valid heal target found.");
-                    }
-
-                    return true;
-                }
-            }
-        }
-
-
-        return false; // No matching item to consume
-    }
-
-    private void ProcessWeaponForActivation(Weapon weapon, string lowerAction, Enemy enemy)
-    {
-        if (weapon == null || enemy == null)
-            return;
-
-        // Extract words from the action string
-        var actionWords = Regex.Matches(lowerAction, @"\b\w+\b")
-                               .Cast<Match>()
-                               .Select(m => m.Value.ToLower())
-                               .ToHashSet(); // For fast keyword lookup
-
-        bool keywordFound = false;
-
-        foreach (string keyword in weapon.keyWords)
-        {
-            if (!string.IsNullOrWhiteSpace(keyword) && actionWords.Contains(keyword.ToLower()))
-            {
-                if (!keywordFound)
-                {
-                    weapon.isActive = true;
-                    enemy.activeItem.Add(weapon);
-                    keywordFound = true;
-                }
-
-                Debug.Log($"Sub_Weapon '{weapon.itemName}' activated by keyword: '{keyword}' from action: '{lowerAction}'");
-            }
-        }
-
-        if (!keywordFound)
-        {
-            Debug.Log($"Sub_Weapon '{weapon.itemName}' remains inactive - no keywords matched");
-        }
     }
 
     public void SetUserMessage(string message)

--- a/LlmGame/Assets/Script/CharacterActionData.cs
+++ b/LlmGame/Assets/Script/CharacterActionData.cs
@@ -7,6 +7,9 @@ public class CharacterActionData : ScriptableObject
     public string actionName;
     public string animationTrigger;
 
+    [Tooltip("Number of turns before this action resolves. 0 means immediate.")]
+    public int delayTurns = 0;
+
     [Header("Multi-Hit Setup")]
     [Tooltip("List of effects and damage split for each hit.")]
     public List<HitEffectData> hitEffects = new List<HitEffectData> { new HitEffectData() };

--- a/LlmGame/Assets/Script/CharacterCombatHandler.cs
+++ b/LlmGame/Assets/Script/CharacterCombatHandler.cs
@@ -191,7 +191,7 @@ public class CharacterCombatHandler : MonoBehaviour
     // เริ่มต้นการโจมตีของศัตรู
     public void EnemyAttack(Character enemy, Character target, CharacterActionData chosenAction)
     {
-        battleManager.StartCoroutine(battleManager.chatAI.SendEnemyMessage(enemy, target, chosenAction.actionName));
+        battleManager.StartCoroutine(battleManager.chatAI.SendEnemyMessage(enemy, target, chosenAction));
     }
 
     public IEnumerator ResolveEnemyAttack(Character enemy, Character target, CharacterActionData chosenAction, float feasibility, float potential, string effectValue, string effectDesc)
@@ -305,7 +305,7 @@ public class CharacterCombatHandler : MonoBehaviour
         yield return battleManager.StartCoroutine(EndEnemyTurn());
     }
 
-    private IEnumerator EndEnemyTurn()
+    public IEnumerator EndEnemyTurn()
     {
         yield return new WaitForSeconds(2.0f);
 

--- a/LlmGame/Assets/Script/ChatAI.cs
+++ b/LlmGame/Assets/Script/ChatAI.cs
@@ -199,10 +199,10 @@ public class ChatAI : MonoBehaviour
 
     }
 
-    public IEnumerator SendEnemyMessage(Character enemy, Character target, string proposedAction)
+    public IEnumerator SendEnemyMessage(Character enemy, Character target, CharacterActionData action)
     {
         // === STEP 1: Initial AI Prompt (Enemy Intent) ===
-        string prompt = PromptBuilder.BuildEnemyPrompt(battleManager, enemy, target, proposedAction);
+        string prompt = PromptBuilder.BuildEnemyPrompt(battleManager, enemy, target, action);
         string json = "{\"message\":\"" + EscapeJsonString(prompt) + "\"}";
         Debug.Log("<color=yellow>[SendEnemyMessage] Initial Prompt:</color>\n" + prompt);
 
@@ -275,6 +275,28 @@ public class ChatAI : MonoBehaviour
             Debug.LogError("[SendEnemyMessage] Failed to get valid response after max attempts.");
             baseFeasibility = 5;
             basePotential = 5;
+        }
+
+        if (action.delayTurns > 0)
+        {
+            baseFeasibility = 10f;
+            basePotential = 0f;
+
+            string log = $"Turn {battleManager.turnCount}: {enemy.characterName} prepares {action.actionName}, warning {target.characterName}.";
+            battleManager.battleLog.Add(log);
+            Debug.Log(log);
+
+            responseText.text += $"\n\n<color=#00ffcc><b>Result:</b></color>\n" +
+                                 $"Feasibility: {baseFeasibility} ({baseFeasibilityDesc})\n" +
+                                 $"Potential: {basePotential} ({basePotentialDesc})\n" +
+                                 $"Effect: {baseEffect}";
+
+            Canvas.ForceUpdateCanvases();
+            scrollRect.verticalNormalizedPosition = 0f;
+            Debug.Log("<color=white>[Final AI Result]</color>:\n" + responseText.text);
+
+            yield return battleManager.StartCoroutine(battleManager.combatHandler.EndEnemyTurn());
+            yield break;
         }
 
         // === STEP 2: Apply Enemy Attack Using Initial Response ===

--- a/LlmGame/Assets/Script/PromptBuilder.cs
+++ b/LlmGame/Assets/Script/PromptBuilder.cs
@@ -88,8 +88,9 @@ public static class PromptBuilder
     }
 
 
-    public static string BuildEnemyPrompt(BattleManager battleManager, Character enemy, Character target, string proposedAction)
+    public static string BuildEnemyPrompt(BattleManager battleManager, Character enemy, Character target, CharacterActionData action)
     {
+        string proposedAction = action.actionName;
         string history = GetBattleHistory(battleManager);
 
         string effect = battleManager.combatHandler.TryApplyStatusEffects(enemy, target);
@@ -125,6 +126,7 @@ public static class PromptBuilder
 
         Proposed action by {enemy.characterName}:
         {proposedAction}
+        {(action.delayTurns > 0 ? $"This action is delayed by {action.delayTurns} turn(s), giving the player a warning to react." : string.Empty)}
 
         The effect that occurs: {effect}
 


### PR DESCRIPTION
## Summary
- let enemies swing with their equipped weapon by default so they can trigger critical hits and other status effects
- add optional turn delay to action data and describe delayed enemy moves in prompts
- skip enemy attack resolution when an action is delayed, logging a warning with fixed feasibility 10 and potential 0

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a992819088832290704865ab3da92b