### PR TITLE
Add delayed attack handling and random enemy actions

### DIFF
--- a/LlmGame/Assets/Script/BattleManager.cs
+++ b/LlmGame/Assets/Script/BattleManager.cs
@@ -200,7 +200,23 @@ public class BattleManager : MonoBehaviour
                 yield break;
             }
 
-            enemy.selectedAction = enemy.availableActions[0];
+            // Use any previously charged attack if present, otherwise pick a random action
+            if (enemy.pendingDelayedAction != null)
+            {
+                enemy.selectedAction = enemy.pendingDelayedAction;
+                enemy.pendingDelayedAction = null;
+            }
+            else
+            {
+                int index = Random.Range(0, enemy.availableActions.Count);
+                enemy.selectedAction = enemy.availableActions[index];
+
+                if (enemy.selectedAction.delayTurns > 0 && enemy.selectedAction.delayedAction != null)
+                {
+                    enemy.pendingDelayedAction = enemy.selectedAction.delayedAction;
+                }
+            }
+
             if (enemy.selectedAction == null)
             {
                 Debug.LogError($"{enemy.characterName} has a null selectedAction.");

--- a/LlmGame/Assets/Script/Character.cs
+++ b/LlmGame/Assets/Script/Character.cs
@@ -44,6 +44,7 @@ public class Character : MonoBehaviour
     [Header("Actions")]
     public List<CharacterActionData> availableActions = new List<CharacterActionData>();
     public CharacterActionData selectedAction;
+    public CharacterActionData pendingDelayedAction;
     public int pendingDamage;
     public List<float> damagePortions = new List<float>();
     public Character damageTarget;

--- a/LlmGame/Assets/Script/CharacterActionData.cs
+++ b/LlmGame/Assets/Script/CharacterActionData.cs
@@ -10,6 +10,9 @@ public class CharacterActionData : ScriptableObject
     [Tooltip("Number of turns before this action resolves. 0 means immediate.")]
     public int delayTurns = 0;
 
+    [Tooltip("If this is a charging move, the action that will be executed after the delay.")]
+    public CharacterActionData delayedAction;
+
     [Header("Multi-Hit Setup")]
     [Tooltip("List of effects and damage split for each hit.")]
     public List<HitEffectData> hitEffects = new List<HitEffectData> { new HitEffectData() };


### PR DESCRIPTION
## Summary
- support follow-up actions for charged moves via `CharacterActionData.delayedAction`
- allow characters to queue delayed attacks for later execution
- randomize enemy action selection and trigger queued special attacks

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a2acd0e48322aeaee8f785d21d8c