### PR TITLE
Implement boss phase-based skill behavior

### DIFF
--- a/LlmGame/Assets/Script/BattleManager.cs
+++ b/LlmGame/Assets/Script/BattleManager.cs
@@ -94,6 +94,24 @@ public class BattleManager : MonoBehaviour
         }
     }
 
+    public Enemy SpawnExtraEnemy(GameObject prefab)
+    {
+        if (prefab == null || enemySpawnPoints == null || enemySpawnPoints.Length == 0)
+            return null;
+
+        Transform spawnPoint = enemySpawnPoints[Random.Range(0, enemySpawnPoints.Length)];
+        GameObject enemyObj = Instantiate(prefab, spawnPoint.position, spawnPoint.rotation);
+        Enemy enemy = enemyObj.GetComponent<Enemy>();
+        if (enemy != null)
+        {
+            enemy.turnGauge = 0f;
+            enemies.Add(enemy);
+            allCharacters.Add(enemy);
+        }
+
+        return enemy;
+    }
+
     private EnemyGroup GetRandomEnemyGroup(NodeType type, EnemyDifficulty difficulty)
     {
         List<EnemyGroup> pool = null;
@@ -200,20 +218,42 @@ public class BattleManager : MonoBehaviour
                 yield break;
             }
 
-            // Use any previously charged attack if present, otherwise pick a random action
-            if (enemy.pendingDelayedAction != null)
+            BossSkillBehavior bossAI = enemy.GetComponent<BossSkillBehavior>();
+
+            if (enemy.archetype == EnemyArchetype.Boss && bossAI != null)
             {
-                enemy.selectedAction = enemy.pendingDelayedAction;
-                enemy.pendingDelayedAction = null;
+                CharacterActionData action = bossAI.DecideAction();
+
+                if (bossAI.HandleSpecialAction(action))
+                {
+                    yield return StartCoroutine(combatHandler.EndEnemyTurn());
+                    yield break;
+                }
+
+                enemy.selectedAction = action;
+
+                if (enemy.selectedAction != null && enemy.selectedAction.delayTurns > 0 && enemy.selectedAction.delayedAction != null)
+                {
+                    enemy.pendingDelayedAction = enemy.selectedAction.delayedAction;
+                }
             }
             else
             {
-                int index = Random.Range(0, enemy.availableActions.Count);
-                enemy.selectedAction = enemy.availableActions[index];
-
-                if (enemy.selectedAction.delayTurns > 0 && enemy.selectedAction.delayedAction != null)
+                // Use any previously charged attack if present, otherwise pick a random action
+                if (enemy.pendingDelayedAction != null)
                 {
-                    enemy.pendingDelayedAction = enemy.selectedAction.delayedAction;
+                    enemy.selectedAction = enemy.pendingDelayedAction;
+                    enemy.pendingDelayedAction = null;
+                }
+                else
+                {
+                    int index = Random.Range(0, enemy.availableActions.Count);
+                    enemy.selectedAction = enemy.availableActions[index];
+
+                    if (enemy.selectedAction.delayTurns > 0 && enemy.selectedAction.delayedAction != null)
+                    {
+                        enemy.pendingDelayedAction = enemy.selectedAction.delayedAction;
+                    }
                 }
             }
 

--- a/LlmGame/Assets/Script/BossSkillBehavior.cs
+++ b/LlmGame/Assets/Script/BossSkillBehavior.cs
@@ -1,0 +1,91 @@
+using System.Linq;
+using UnityEngine;
+
+public class BossSkillBehavior : MonoBehaviour
+{
+    private Enemy enemy;
+    public BattleManager battleManager;
+
+    [Header("Phase 1")]
+    public CharacterActionData summonThugs;
+    public CharacterActionData smokeVeil;
+    public CharacterActionData rallyOrders;
+
+    [Header("Phase 2")]
+    public CharacterActionData executionBullet;
+    public CharacterActionData kingsFury;
+
+    [Header("Summon Prefabs")]
+    public GameObject pipeManPrefab;
+    public GameObject robotPrefab;
+
+    private int summonUseCount = 0;
+    private bool smokeVeilUsed = false;
+    private bool kingsFuryUsed = false;
+
+    private void Awake()
+    {
+        enemy = GetComponent<Enemy>();
+        if (battleManager == null)
+            battleManager = FindObjectOfType<BattleManager>();
+    }
+
+    public CharacterActionData DecideAction()
+    {
+        if (enemy == null) return null;
+        float hpPercent = (float)enemy.currentHP / enemy.maxHP;
+
+        if (hpPercent <= 0.5f)
+        {
+            if (!kingsFuryUsed && kingsFury != null)
+            {
+                kingsFuryUsed = true;
+                return kingsFury;
+            }
+            return executionBullet;
+        }
+
+        if (summonUseCount < 2)
+        {
+            bool first = hpPercent <= 0.8f && summonUseCount == 0;
+            bool second = hpPercent <= 0.6f && summonUseCount == 1;
+            if (first || second)
+                return summonThugs;
+        }
+
+        if (!smokeVeilUsed && battleManager != null && battleManager.enemies.Any(e => e != enemy && e.IsAlive()))
+        {
+            smokeVeilUsed = true;
+            return smokeVeil;
+        }
+
+        if (battleManager != null && battleManager.enemies.Any(e => e != enemy && e.IsAlive()) && Random.value < 0.5f)
+        {
+            return rallyOrders;
+        }
+
+        return enemy.availableActions.FirstOrDefault(a =>
+            a != null &&
+            a != summonThugs &&
+            a != smokeVeil &&
+            a != rallyOrders &&
+            a != executionBullet &&
+            a != kingsFury) ?? enemy.availableActions.FirstOrDefault();
+    }
+
+    public bool HandleSpecialAction(CharacterActionData action)
+    {
+        if (action == summonThugs)
+        {
+            summonUseCount++;
+            int count = Random.Range(1, 3);
+            for (int i = 0; i < count; i++)
+            {
+                GameObject prefab = Random.value < 0.5f ? pipeManPrefab : robotPrefab;
+                battleManager?.SpawnExtraEnemy(prefab);
+            }
+            return true;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- Add `BossSkillBehavior` component controlling boss phases and skills
- Support summoning minions and buffs, including execution bullet and king's fury
- Allow BattleManager to spawn extra enemies and delegate boss action selection

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa6d91ea48322807e38b09558a79c