### PR TITLE
Display turn number and status effects in chat

### DIFF
--- a/LlmGame/Assets/Script/BattleManager.cs
+++ b/LlmGame/Assets/Script/BattleManager.cs
@@ -166,7 +166,13 @@ public class BattleManager : MonoBehaviour
                 foreach (var listener in character.GetComponentsInChildren<ITurnListener>())
                     listener.OnTurnStart(character);
 
-                character.ProcessStatusEffects();
+                string statusLog = character.ProcessStatusEffects();
+                if (!string.IsNullOrEmpty(statusLog))
+                {
+                    chatAI.responseText.text += $"Turn {turnCount} Start: {statusLog}\n";
+                    Canvas.ForceUpdateCanvases();
+                    chatAI.scrollRect.verticalNormalizedPosition = 0f;
+                }
 
                 foreach (var listener in character.GetComponentsInChildren<ITurnListener>())
                     listener.OnTurnEnd(character);

--- a/LlmGame/Assets/Script/Character.cs
+++ b/LlmGame/Assets/Script/Character.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using UnityEngine;
 
 public class Character : MonoBehaviour
@@ -358,15 +359,20 @@ public class Character : MonoBehaviour
     }
 
 
-    public virtual void ProcessStatusEffects()
+    public virtual string ProcessStatusEffects()
     {
+        var sb = new StringBuilder();
+
         if (mpRegenPerTurn > 0)
         {
             int before = currentMP;
             currentMP = Mathf.Min(maxMP, currentMP + mpRegenPerTurn);
             int gained = currentMP - before;
             if (gained > 0)
+            {
                 Debug.Log($"{characterName} regenerates {gained} MP.");
+                sb.AppendLine($"{characterName} regenerates {gained} MP.");
+            }
         }
 
         for (int i = activeStatusEffects.Count - 1; i >= 0; i--)
@@ -377,6 +383,7 @@ public class Character : MonoBehaviour
             {
                 case StatusEffectType.Stun:
                     Debug.Log($"{characterName} is stunned and will skip this turn.");
+                    sb.AppendLine($"{characterName} is stunned and will skip this turn.");
                     break;
 
                 // 🔻 Debuffs
@@ -461,6 +468,7 @@ public class Character : MonoBehaviour
                         if (characterType == CharacterType.Android)
                             radDamage *= 2;
                         Debug.Log($"{characterName} suffers RADIATION for {radDamage} damage.");
+                        sb.AppendLine($"{characterName} suffers RADIATION for {radDamage} damage.");
                         TakeDamage(radDamage);
                         TryApplyHealReductionDebuff(effect.source);
                         break;
@@ -490,6 +498,7 @@ public class Character : MonoBehaviour
                         if (spreadToAllParts)
                         {
                             Debug.Log($"{characterName} suffers BLEED on ALL parts for {bleedDamage} damage.");
+                            sb.AppendLine($"{characterName} suffers BLEED on ALL parts for {bleedDamage} damage.");
                             if (currentshield <= 0)
                             {
                                 foreach (var part in bodyParts)
@@ -502,6 +511,7 @@ public class Character : MonoBehaviour
                         else
                         {
                             Debug.Log($"{characterName} suffers BLEED for {bleedDamage} damage.");
+                            sb.AppendLine($"{characterName} suffers BLEED for {bleedDamage} damage.");
                             TakeDamage(bleedDamage);
 
                             // 🔔 Notify observers (e.g., Blood Rush Core)
@@ -523,6 +533,7 @@ public class Character : MonoBehaviour
                         else if (effect.magnitude >= 3) poisonPercent = 0.15f;
                         int poisonDamage = Mathf.RoundToInt(maxHP * poisonPercent);
                         Debug.Log($"{characterName} suffers POISON for {poisonDamage} damage.");
+                        sb.AppendLine($"{characterName} suffers POISON for {poisonDamage} damage.");
                         TakeDamage(poisonDamage);
                         TryApplyNerveRotVialDebuff(effect.source);
                         break;
@@ -568,6 +579,7 @@ public class Character : MonoBehaviour
                 }
 
                 Debug.Log($"{characterName} is no longer affected by {effect.effectType}.");
+                sb.AppendLine($"{characterName} is no longer affected by {effect.effectType}.");
                 activeStatusEffects.RemoveAt(i);
             }
         }
@@ -588,6 +600,8 @@ public class Character : MonoBehaviour
         }
 
         StatusEffectsChanged?.Invoke();
+
+        return sb.ToString();
     }
 
     private void TryApplyNerveRotVialDebuff(Character source)

--- a/LlmGame/Assets/Script/ChatAI.cs
+++ b/LlmGame/Assets/Script/ChatAI.cs
@@ -22,6 +22,8 @@ public class ChatAI : MonoBehaviour
     public string baseEffect = "";
     public string baseEffectDesc = "";
 
+    public string turnEffectText = "";
+
     private string apiUrl = "https://diphtxovye.execute-api.ap-northeast-1.amazonaws.com/chatWithAI";
 
     private void Awake()
@@ -62,20 +64,22 @@ public class ChatAI : MonoBehaviour
         battleManager.SetUserMessage(safeMessage);
         PromptBuilder.CheckAndActivateItems(battleManager, userMessage, targetEnemy);
 
+        turnEffectText = battleManager.combatHandler.TryApplyStatusEffects(battleManager.player, targetEnemy);
+
         List<DamageType> enemyDamageTypes = new List<DamageType>();
         foreach (var weapon in targetEnemy.activeItem.OfType<Weapon>())
         {
             enemyDamageTypes.AddRange(weapon.damageType);
         }
 
-        string finalPrompt = PromptBuilder.BuildPlayerPrompt(battleManager, targetEnemy, safeMessage);
+        string finalPrompt = PromptBuilder.BuildPlayerPrompt(battleManager, targetEnemy, safeMessage, turnEffectText);
         StartCoroutine(SendMessageToAI(finalPrompt));
     }
 
     public IEnumerator SendMessageToAI(string userMessage)
     {
         // ✅ Optional: Simulate "thinking" delay before sending the prompt
-        responseText.text = "<i>AI is thinking...</i>";
+        responseText.text = $"Turn {battleManager.turnCount}: {battleManager.player.characterName} attacks to inflict a Critical or Status Effect. {turnEffectText}\n<i>AI is thinking...</i>";
         yield return new WaitForSeconds(1.5f); // Adjust this value as needed
 
         Character targetEnemy = battleManager.selectedTarget;
@@ -200,10 +204,11 @@ public class ChatAI : MonoBehaviour
     public IEnumerator SendEnemyMessage(Character enemy, Character target, CharacterActionData action)
     {
         // ✅ Optional: Simulate "thinking" delay for enemy AI
-        responseText.text = "<i>Enemy is planning...</i>";
+        turnEffectText = battleManager.combatHandler.TryApplyStatusEffects(enemy, target);
+        responseText.text = $"Turn {battleManager.turnCount}: {enemy.characterName} attacks to inflict a Critical or Status Effect. {turnEffectText}\n<i>Enemy is planning...</i>";
         yield return new WaitForSeconds(1f); // You can increase for more drama
 
-        string prompt = PromptBuilder.BuildEnemyPrompt(battleManager, enemy, target, action);
+        string prompt = PromptBuilder.BuildEnemyPrompt(battleManager, enemy, target, action, turnEffectText);
         string json = "{\"message\":\"" + EscapeJsonString(prompt) + "\"}";
         Debug.Log("<color=yellow>[SendEnemyMessage] Initial Prompt:</color>\n" + prompt);
 

--- a/LlmGame/Assets/Script/DamageModifierSkill.cs
+++ b/LlmGame/Assets/Script/DamageModifierSkill.cs
@@ -104,8 +104,9 @@ public class DamageModifierSkill : ScriptableObject
 
         // ✅ Trigger skill-related item and defense checks
         PromptBuilder.CheckAndActivateItems(battleManager, skillMessage, target);
-        // ✅ Build and send prompt to AI
-        string finalPrompt = PromptBuilder.BuildPlayerPrompt(battleManager, target, skillMessage);
+        // ✅ Apply status effects and build prompt
+        battleManager.chatAI.turnEffectText = battleManager.combatHandler.TryApplyStatusEffects(battleManager.player, target);
+        string finalPrompt = PromptBuilder.BuildPlayerPrompt(battleManager, target, skillMessage, battleManager.chatAI.turnEffectText);
         battleManager.StartCoroutine(battleManager.chatAI.SendMessageToAI(finalPrompt));
 
         // ⚠️ End turn and reset flags should be done by BattleManager after skill resolves

--- a/LlmGame/Assets/Script/PromptBuilder.cs
+++ b/LlmGame/Assets/Script/PromptBuilder.cs
@@ -6,11 +6,9 @@ using Unity.VisualScripting;
 
 public static class PromptBuilder
 {
-    public static string BuildPlayerPrompt(BattleManager battleManager, Character targetEnemy, string userMessage)
+    public static string BuildPlayerPrompt(BattleManager battleManager, Character targetEnemy, string userMessage, string effect)
     {
         string history = GetBattleHistory(battleManager);
-
-        string effect = battleManager.combatHandler.TryApplyStatusEffects(battleManager.player, targetEnemy);
 
         // Detect selected parts in enemy based on user's action
         if (battleManager.player.isUsingUltimateSkill == false) PromptBuilder.DetectSelectedBodyParts(userMessage, targetEnemy, battleManager);
@@ -88,12 +86,10 @@ public static class PromptBuilder
     }
 
 
-    public static string BuildEnemyPrompt(BattleManager battleManager, Character enemy, Character target, CharacterActionData action)
+    public static string BuildEnemyPrompt(BattleManager battleManager, Character enemy, Character target, CharacterActionData action, string effect)
     {
         string proposedAction = action.actionName;
         string history = GetBattleHistory(battleManager);
-
-        string effect = battleManager.combatHandler.TryApplyStatusEffects(enemy, target);
 
         // Detect selected parts in player based on enemy's action
         PromptBuilder.DetectSelectedBodyParts(proposedAction, target, battleManager);


### PR DESCRIPTION
## Summary
- show the current turn and pre-attack effect summary in chat messages
- log start-of-turn status effect damage in chat
- allow prompt builder and skills to pass along effect summaries

## Testing
- `dotnet build 2>&1 | head -n 20` *(command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2c279b8c8322be48ae68c86bb551