### PR TITLE
Implement boss skill feasibility overrides

### DIFF
--- a/LlmGame/Assets/Script/BossSkillBehavior.cs
+++ b/LlmGame/Assets/Script/BossSkillBehavior.cs
@@ -149,4 +149,22 @@ public class BossSkillBehavior : MonoBehaviour
 
         return false;
     }
+
+    public bool TryGetBossSkillOutcome(CharacterActionData action, out float feasibility, out float potential)
+    {
+        feasibility = 0f;
+        potential = 0f;
+
+        if (action == null)
+            return false;
+
+        if (action == summonThugs || action == smokeVeil || action == kingsFury)
+        {
+            feasibility = 10f;
+            potential = 0f;
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/LlmGame/Assets/Script/ChatAI.cs
+++ b/LlmGame/Assets/Script/ChatAI.cs
@@ -205,6 +205,23 @@ public class ChatAI : MonoBehaviour
         AppendResponse($"Turn {battleManager.turnCount}: {enemy.characterName} attacks to inflict a Critical or Status Effect. {turnEffectText}\n<i>Enemy is planning...</i>");
         yield return new WaitForSeconds(1f); // You can increase for more drama
 
+        var bossBehavior = enemy != null ? enemy.GetComponent<BossSkillBehavior>() : null;
+        if (bossBehavior != null && bossBehavior.TryGetBossSkillOutcome(action, out float skillFeas, out float skillPot))
+        {
+            baseFeasibility = skillFeas;
+            basePotential = skillPot;
+            baseFeasibilityDesc = "Boss skill";
+            basePotentialDesc = "No damage";
+            baseEffect = action != null ? action.actionName : "";
+            baseEffectDesc = "";
+
+            AppendResponse($"\n<color=#00ffcc><b>Result:</b></color>\n" +
+                           $"Feasibility: {baseFeasibility} ({baseFeasibilityDesc})\n" +
+                           $"Potential: {basePotential} ({basePotentialDesc})\n" +
+                           $"Effect: {baseEffect}");
+            yield break;
+        }
+
         string prompt = PromptBuilder.BuildEnemyPrompt(battleManager, enemy, target, action, turnEffectText);
         string json = "{\"message\":\"" + EscapeJsonString(prompt) + "\"}";
         Debug.Log("<color=yellow>[SendEnemyMessage] Initial Prompt:</color>\n" + prompt);


### PR DESCRIPTION
## Summary
- Provide fixed feasibility and potential outcomes for boss-only skills
- Let AI handler skip API calls and assume no damage for special boss skills

## Testing
- ⚠️ `dotnet test` (dotnet: command not found)

------
https://chatgpt.com/codex/tasks/task_e_68ac349d879c8322a882827aa028c2dc