### PR TITLE
Fix boss action logic and UI safeguards

### DIFF
--- a/LlmGame/Assets/Script/BattleManager.cs
+++ b/LlmGame/Assets/Script/BattleManager.cs
@@ -257,8 +257,9 @@ public class BattleManager : MonoBehaviour
                 // Special case: handle summon or other unique behavior
                 if (bossAI.HandleSpecialAction(action))
                 {
+                    battleLog.Add($"Turn {turnCount}: {enemy.characterName} used {action.actionName}.");
                     yield return StartCoroutine(combatHandler.EndEnemyTurn());
-                    //yield break;
+                    yield break;
                 }
 
                 enemy.selectedAction = action;

--- a/LlmGame/Assets/Script/BossActionEffect.cs
+++ b/LlmGame/Assets/Script/BossActionEffect.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+public class BossActionEffect : MonoBehaviour
+{
+    public GameObject effectPrefab;
+
+    public void PlayEffect()
+    {
+        if (effectPrefab == null) return;
+        GameObject fx = Instantiate(effectPrefab, transform.position, Quaternion.identity);
+        Destroy(fx, 5f);
+    }
+}

--- a/LlmGame/Assets/Script/BossActionEffect.cs.meta
+++ b/LlmGame/Assets/Script/BossActionEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 97d4193692b94922bfa5b3b5834536b2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/LlmGame/Assets/Script/BossSkillBehavior.cs
+++ b/LlmGame/Assets/Script/BossSkillBehavior.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using UnityEngine;
+using System.Collections.Generic;
 
 public class BossSkillBehavior : MonoBehaviour
 {
@@ -18,6 +19,7 @@ public class BossSkillBehavior : MonoBehaviour
     [Header("Summon Prefabs")]
     public GameObject pipeManPrefab;
     public GameObject robotPrefab;
+    public BossActionEffect actionEffect;
 
     private int summonUseCount = 0;
     private bool smokeVeilUsed = false;
@@ -41,6 +43,11 @@ public class BossSkillBehavior : MonoBehaviour
     public CharacterActionData DecideAction()
     {
         if (enemy == null) return null;
+
+        if (summonUseCount == 0 && battleManager != null && battleManager.turnCount == 1 && summonThugs != null)
+        {
+            return summonThugs;
+        }
 
         if (enemy.pendingDelayedAction != null)
         {
@@ -78,12 +85,19 @@ public class BossSkillBehavior : MonoBehaviour
             return rallyOrders;
         }
 
-        return enemy.availableActions.FirstOrDefault(a =>
-            a != null &&
-            a != smokeVeil &&
-            a != rallyOrders &&
-            a != executionBullet &&
-            a != kingsFury) ?? enemy.availableActions.FirstOrDefault();
+        List<CharacterActionData> candidates = enemy.availableActions
+            .Where(a => a != null &&
+                        a != summonThugs &&
+                        a != smokeVeil &&
+                        a != rallyOrders &&
+                        a != executionBullet &&
+                        a != kingsFury)
+            .ToList();
+
+        if (candidates.Count > 0)
+            return candidates[Random.Range(0, candidates.Count)];
+
+        return enemy.availableActions[Random.Range(0, enemy.availableActions.Count)];
     }
 
     public bool HandleSpecialAction(CharacterActionData action)
@@ -102,12 +116,14 @@ public class BossSkillBehavior : MonoBehaviour
                 battleManager?.SpawnExtraEnemy(prefab, index);
             }
 
+            actionEffect?.PlayEffect();
             return true;
         }
 
         if (action == smokeVeil)
         {
             smokeVeilActive = true;
+            actionEffect?.PlayEffect();
             return true;
         }
 
@@ -119,6 +135,7 @@ public class BossSkillBehavior : MonoBehaviour
                 TurnStatusEffect buff = new(buffType, 2, 1, enemy);
                 ally.ApplyStatusEffect(buff);
             }
+            actionEffect?.PlayEffect();
             return true;
         }
 
@@ -135,6 +152,7 @@ public class BossSkillBehavior : MonoBehaviour
             TurnStatusEffect spd = new(StatusEffectType.SpeedUp, 2, 1, enemy);
             enemy.ApplyStatusEffect(atk);
             enemy.ApplyStatusEffect(spd);
+            actionEffect?.PlayEffect();
             return true;
         }
 

--- a/LlmGame/Assets/Script/Character.cs
+++ b/LlmGame/Assets/Script/Character.cs
@@ -195,11 +195,19 @@ public class Character : MonoBehaviour
                 if (behavior is IDeathListener deathListener)
                 {
                     deathListener.OnDeath(this);
-                    Destroy(gameObject, 1f);
                 }
             }
         }
 
+        if (battleManager != null)
+        {
+            if (this is Enemy enemy)
+                battleManager.enemies.Remove(enemy);
+            battleManager.allCharacters.Remove(this);
+        }
+
+        if (this is Enemy)
+            Destroy(gameObject);
     }
 
     private void OnMouseDown()

--- a/LlmGame/Assets/Script/ChatAI.cs
+++ b/LlmGame/Assets/Script/ChatAI.cs
@@ -14,6 +14,7 @@ public class ChatAI : MonoBehaviour
     public TMP_Text responseText;
     public GameObject inputPanel;
     public ScrollRect scrollRect;
+    public Button sendButton;
 
     public float baseFeasibility = 0f;
     public float basePotential = 0f;
@@ -71,6 +72,9 @@ public class ChatAI : MonoBehaviour
         {
             enemyDamageTypes.AddRange(weapon.damageType);
         }
+
+        if (sendButton != null)
+            sendButton.gameObject.SetActive(false);
 
         string finalPrompt = PromptBuilder.BuildPlayerPrompt(battleManager, targetEnemy, safeMessage, turnEffectText);
         StartCoroutine(SendMessageToAI(finalPrompt));
@@ -334,10 +338,7 @@ public class ChatAI : MonoBehaviour
     private void AppendResponse(string message)
     {
         if (responseText == null) return;
-        if (!string.IsNullOrEmpty(responseText.text))
-            responseText.text += "\n";
-
-        responseText.text += message;
+        responseText.text += message + "\n";
         Canvas.ForceUpdateCanvases();
         if (scrollRect != null)
             scrollRect.verticalNormalizedPosition = 0f;
@@ -403,11 +404,15 @@ public class ChatAI : MonoBehaviour
     {
         if (inputPanel != null)
             inputPanel.SetActive(true);
+        if (sendButton != null)
+            sendButton.gameObject.SetActive(true);
     }
 
     public void HideInputUI()
     {
         if (inputPanel != null)
             inputPanel.SetActive(false);
+        if (sendButton != null)
+            sendButton.gameObject.SetActive(false);
     }
 }

--- a/LlmGame/Assets/Script/DamageModifierSkill.cs
+++ b/LlmGame/Assets/Script/DamageModifierSkill.cs
@@ -62,11 +62,11 @@ public class DamageModifierSkill : ScriptableObject
         }
         else if (skillName == "Multi-Target Scan")
         {
-            Debug.Log("buff user: next 3 attacks have +100% crit chance and +100% crit damage");
+            Debug.Log("buff user: next 3 attacks gain +100 attack and +100% crit chance");
+            var atkUp = new TurnStatusEffect(StatusEffectType.AttackUp, 3, 100, user);
+            user.ApplyStatusEffect(atkUp);
             var critChance = new TurnStatusEffect(StatusEffectType.CritChanceUp, 3, 100, user);
             user.ApplyStatusEffect(critChance);
-            var critDamage = new TurnStatusEffect(StatusEffectType.CritDamageUp, 3, 100, user);
-            user.ApplyStatusEffect(critDamage);
         }
 
         /*


### PR DESCRIPTION
## Summary
- Prevent double submits by hiding the send button after use and showing responses on new lines
- Correct Multi-Target Scan to boost attack and crit chance
- Overhaul boss skill behavior: random actions, single first-round summon, effect hook, and battle log entries
- Clean up defeated enemies by removing their objects

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5778d378832280c778cd994f0b03