### PR TITLE
Adjust boss behavior probability and chat scrolling

### DIFF
--- a/LlmGame/Assets/Script/BattleManager.cs
+++ b/LlmGame/Assets/Script/BattleManager.cs
@@ -198,9 +198,7 @@ public class BattleManager : MonoBehaviour
                 string statusLog = character.ProcessStatusEffects();
                 if (!string.IsNullOrEmpty(statusLog))
                 {
-                    chatAI.responseText.text += $"Turn {turnCount} Start: {statusLog}\n";
-                    Canvas.ForceUpdateCanvases();
-                    chatAI.scrollRect.verticalNormalizedPosition = 0f;
+                    chatAI.AppendResponse($"Turn {turnCount} Start: {statusLog}");
                 }
 
                 foreach (var listener in character.GetComponentsInChildren<ITurnListener>())
@@ -252,20 +250,39 @@ public class BattleManager : MonoBehaviour
 
             if (enemy.archetype == EnemyArchetype.Boss && bossAI != null)
             {
-                CharacterActionData action = bossAI.DecideAction();
-
-                // Special case: handle summon or other unique behavior
-                if (bossAI.HandleSpecialAction(action))
+                if (Random.value < 0.25f)
                 {
-                    battleLog.Add($"Turn {turnCount}: {enemy.characterName} used {action.actionName}.");
-                    yield return StartCoroutine(combatHandler.EndEnemyTurn());
-                    yield break;
+                    CharacterActionData action = bossAI.DecideAction();
+
+                    if (bossAI.HandleSpecialAction(action))
+                    {
+                        battleLog.Add($"Turn {turnCount}: {enemy.characterName} used {action.actionName}.");
+                        chatAI?.AppendResponse($"Turn {turnCount}: {enemy.characterName} used {action.actionName}");
+                        yield return StartCoroutine(combatHandler.EndEnemyTurn());
+                        yield break;
+                    }
+
+                    enemy.selectedAction = action;
+
+                    if (action != null && action.delayTurns > 0 && action.delayedAction != null)
+                        enemy.pendingDelayedAction = action.delayedAction;
                 }
+                else
+                {
+                    if (enemy.pendingDelayedAction != null)
+                    {
+                        enemy.selectedAction = enemy.pendingDelayedAction;
+                        enemy.pendingDelayedAction = null;
+                    }
+                    else
+                    {
+                        int index = Random.Range(0, enemy.availableActions.Count);
+                        enemy.selectedAction = enemy.availableActions[index];
 
-                enemy.selectedAction = action;
-
-                if (action != null && action.delayTurns > 0 && action.delayedAction != null)
-                    enemy.pendingDelayedAction = action.delayedAction;
+                        if (enemy.selectedAction.delayTurns > 0 && enemy.selectedAction.delayedAction != null)
+                            enemy.pendingDelayedAction = enemy.selectedAction.delayedAction;
+                    }
+                }
             }
             else
             {

--- a/LlmGame/Assets/Script/ChatAI.cs
+++ b/LlmGame/Assets/Script/ChatAI.cs
@@ -335,13 +335,17 @@ public class ChatAI : MonoBehaviour
         Debug.Log("<color=white>[Final AI Result]</color>:\n" + responseText.text);
     }
 
-    private void AppendResponse(string message)
+    public void AppendResponse(string message)
     {
         if (responseText == null) return;
+
+        if (!string.IsNullOrEmpty(responseText.text))
+            responseText.text += "\n";
+
         responseText.text += message + "\n";
         Canvas.ForceUpdateCanvases();
         if (scrollRect != null)
-            scrollRect.verticalNormalizedPosition = 0f;
+            scrollRect.verticalNormalizedPosition = 1f;
     }
 
     public string EscapeJsonString(string str)


### PR DESCRIPTION
## Summary
- ensure response text scrolls to bottom and separate turns with new lines
- add boss special action messages and use boss skills only 25% of the time

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6d478c0483228b89573221d1013a