### PR TITLE
Add toggles for battle result descriptions

### DIFF
--- a/LlmGame/Assets/Scenes/MainMenu/SettingsManager.cs
+++ b/LlmGame/Assets/Scenes/MainMenu/SettingsManager.cs
@@ -8,6 +8,13 @@ public class SettingsManager : MonoBehaviour
     [Header("Assign Audio Mixer")]
     public AudioMixer audioMixer;
 
+    private const string ShowFeasibilityDescKey = "ShowFeasibilityDesc";
+    private const string ShowPotentialDescKey = "ShowPotentialDesc";
+
+    [Header("Display Settings")]
+    public bool showFeasibilityDesc = true;
+    public bool showPotentialDesc = true;
+
     private void Awake()
     {
         if (Instance != null && Instance != this)
@@ -18,6 +25,9 @@ public class SettingsManager : MonoBehaviour
 
         Instance = this;
         DontDestroyOnLoad(gameObject);
+
+        showFeasibilityDesc = PlayerPrefs.GetInt(ShowFeasibilityDescKey, 1) == 1;
+        showPotentialDesc = PlayerPrefs.GetInt(ShowPotentialDescKey, 1) == 1;
     }
 
     public void SetMusicVolume(float volume)
@@ -28,5 +38,17 @@ public class SettingsManager : MonoBehaviour
     public void SetVFXVolume(float volume)
     {
         audioMixer.SetFloat("VFXVolume", Mathf.Log10(Mathf.Clamp(volume, 0.0001f, 1)) * 20);
+    }
+
+    public void SetShowFeasibilityDesc(bool value)
+    {
+        showFeasibilityDesc = value;
+        PlayerPrefs.SetInt(ShowFeasibilityDescKey, value ? 1 : 0);
+    }
+
+    public void SetShowPotentialDesc(bool value)
+    {
+        showPotentialDesc = value;
+        PlayerPrefs.SetInt(ShowPotentialDescKey, value ? 1 : 0);
     }
 }

--- a/LlmGame/Assets/Script/ChatAI.cs
+++ b/LlmGame/Assets/Script/ChatAI.cs
@@ -194,10 +194,7 @@ public class ChatAI : MonoBehaviour
         }
 
         // === FINAL OUTPUT (After Damage Calculation) ===
-        AppendResponse($"\n<color=#00ffcc><b>Result:</b></color>\n" +
-                       $"Feasibility: {baseFeasibility} ({baseFeasibilityDesc})\n" +
-                       $"Potential: {basePotential} ({basePotentialDesc})\n" +
-                       $"Effect: {baseEffect}");
+        AppendResponse(FormatResult());
 
         Debug.Log("<color=white>[Final AI Result]</color>:\n" + responseText.text);
     }
@@ -219,10 +216,7 @@ public class ChatAI : MonoBehaviour
             baseEffect = action != null ? action.actionName : "";
             baseEffectDesc = "";
 
-            AppendResponse($"\n<color=#00ffcc><b>Result:</b></color>\n" +
-                           $"Feasibility: {baseFeasibility} ({baseFeasibilityDesc})\n" +
-                           $"Potential: {basePotential} ({basePotentialDesc})\n" +
-                           $"Effect: {baseEffect}");
+            AppendResponse(FormatResult());
             yield break;
         }
 
@@ -306,10 +300,7 @@ public class ChatAI : MonoBehaviour
             baseFeasibility = 10f;
             basePotential = 0f;
 
-            AppendResponse($"\n<color=#00ffcc><b>Result:</b></color>\n" +
-                           $"Feasibility: {baseFeasibility} ({baseFeasibilityDesc})\n" +
-                           $"Potential: {basePotential} ({basePotentialDesc})\n" +
-                           $"Effect: {baseEffect}");
+            AppendResponse(FormatResult());
 
             yield break;
         }
@@ -327,10 +318,7 @@ public class ChatAI : MonoBehaviour
             )
         );
 
-        AppendResponse($"\n<color=#00ffcc><b>Result:</b></color>\n" +
-                       $"Feasibility: {baseFeasibility} ({baseFeasibilityDesc})\n" +
-                       $"Potential: {basePotential} ({basePotentialDesc})\n" +
-                       $"Effect: {baseEffect}");
+        AppendResponse(FormatResult());
 
         Debug.Log("<color=white>[Final AI Result]</color>:\n" + responseText.text);
     }
@@ -346,6 +334,23 @@ public class ChatAI : MonoBehaviour
         Canvas.ForceUpdateCanvases();
         if (scrollRect != null)
             scrollRect.verticalNormalizedPosition = 1f;
+    }
+
+    private string FormatResult()
+    {
+        string feasLine = $"Feasibility: {baseFeasibility}";
+        if (SettingsManager.Instance == null || SettingsManager.Instance.showFeasibilityDesc)
+            feasLine += $" ({baseFeasibilityDesc})";
+        feasLine += "\\n";
+
+        string potLine = $"Potential: {basePotential}";
+        if (SettingsManager.Instance == null || SettingsManager.Instance.showPotentialDesc)
+            potLine += $" ({basePotentialDesc})";
+        potLine += "\\n";
+
+        string effectLine = $"Effect: {baseEffect}";
+
+        return $"\\n<color=#00ffcc><b>Result:</b></color>\\n" + feasLine + potLine + effectLine;
     }
 
     public string EscapeJsonString(string str)

--- a/LlmGame/Assets/Script/MainMenuController.cs
+++ b/LlmGame/Assets/Script/MainMenuController.cs
@@ -16,6 +16,10 @@ public class MainMenuController : MonoBehaviour
     public Slider musicSlider;
     public Slider vfxSlider;
 
+    [Header("Display Toggles")]
+    public Toggle showFeasibilityDescToggle;
+    public Toggle showPotentialDescToggle;
+
     [Header("Player Config")]
     public DefaultPlayerConfig defaultConfig;
 
@@ -23,6 +27,11 @@ public class MainMenuController : MonoBehaviour
     {
         // Optional auto-start: comment out in production
         // OnStartButton();
+
+        if (showFeasibilityDescToggle != null)
+            showFeasibilityDescToggle.isOn = SettingsManager.Instance.showFeasibilityDesc;
+        if (showPotentialDescToggle != null)
+            showPotentialDescToggle.isOn = SettingsManager.Instance.showPotentialDesc;
     }
 
     public void OnStartButton()
@@ -40,6 +49,11 @@ public class MainMenuController : MonoBehaviour
     public void OnOptionsButton()
     {
         settingsPanel.SetActive(true);
+
+        if (showFeasibilityDescToggle != null)
+            showFeasibilityDescToggle.isOn = SettingsManager.Instance.showFeasibilityDesc;
+        if (showPotentialDescToggle != null)
+            showPotentialDescToggle.isOn = SettingsManager.Instance.showPotentialDesc;
     }
 
     public void OnExitButton()
@@ -64,5 +78,15 @@ public class MainMenuController : MonoBehaviour
     public void OnVFXVolumeChanged(float value)
     {
         SettingsManager.Instance.SetVFXVolume(value);
+    }
+
+    public void OnShowFeasibilityDescChanged(bool value)
+    {
+        SettingsManager.Instance.SetShowFeasibilityDesc(value);
+    }
+
+    public void OnShowPotentialDescChanged(bool value)
+    {
+        SettingsManager.Instance.SetShowPotentialDesc(value);
     }
 }


### PR DESCRIPTION
## Summary
- allow players to toggle feasibility and potential descriptions through settings
- wire toggles into main menu options panel
- format AI result output based on chosen settings

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9f8516f48322bedf2d4a12f52baa