### PR TITLE
Improve battle messaging and status effect cleanup

### DIFF
--- a/LlmGame/Assets/Script/BattleLog.cs
+++ b/LlmGame/Assets/Script/BattleLog.cs
@@ -9,6 +9,7 @@ public class BattleLog : MonoBehaviour
 
     public void Log(string message)
     {
+        message = message.Replace("\\n", "\n");
         responseText.text += message + "\n";
         Canvas.ForceUpdateCanvases(); // Force layout rebuild
         //ScrollToTop();

--- a/LlmGame/Assets/Script/BattleManager.cs
+++ b/LlmGame/Assets/Script/BattleManager.cs
@@ -331,6 +331,7 @@ public class BattleManager : MonoBehaviour
 
     public void EndPlayerTurn()
     {
+        player?.ClearEndTurnEffects();
         isActionPhase = false;
         currentActingCharacter = null;
         selectedTarget = null;
@@ -351,6 +352,7 @@ public class BattleManager : MonoBehaviour
     {
         yield return new WaitForSeconds(1f);
         Debug.Log($"{character.characterName}'s turn was skipped due to stun.");
+        character?.ClearEndTurnEffects();
         isActionPhase = false;
         currentActingCharacter = null;
         //AddPendingCharacters(); // ✅ Still add new characters even on skipped turn

--- a/LlmGame/Assets/Script/BossSkillBehavior.cs
+++ b/LlmGame/Assets/Script/BossSkillBehavior.cs
@@ -175,4 +175,19 @@ public class BossSkillBehavior : MonoBehaviour
 
         return false;
     }
+
+    public string GetSkillDescription(CharacterActionData action)
+    {
+        if (action == summonThugs)
+            return "Summons allies to the fight";
+        if (action == smokeVeil)
+            return "Becomes untargetable while allies remain";
+        if (action == rallyOrders)
+            return "Buffs allies with random attack or defense";
+        if (action == executionBullet)
+            return "A high powered shot with critical potential";
+        if (action == kingsFury)
+            return "Raises the boss's attack and speed";
+        return string.Empty;
+    }
 }

--- a/LlmGame/Assets/Script/Character.cs
+++ b/LlmGame/Assets/Script/Character.cs
@@ -615,6 +615,43 @@ public class Character : MonoBehaviour
         return sb.ToString();
     }
 
+    public void ClearEndTurnEffects()
+    {
+        for (int i = activeStatusEffects.Count - 1; i >= 0; i--)
+        {
+            TurnStatusEffect effect = activeStatusEffects[i];
+            if (effect.isPermanent) continue;
+            switch (effect.effectType)
+            {
+                case StatusEffectType.AttackUp:
+                    attack -= effect.magnitude;
+                    activeStatusEffects.RemoveAt(i);
+                    break;
+                case StatusEffectType.DefenseUp:
+                    defense -= effect.magnitude;
+                    activeStatusEffects.RemoveAt(i);
+                    break;
+                case StatusEffectType.SpeedUp:
+                    speed -= effect.magnitude;
+                    activeStatusEffects.RemoveAt(i);
+                    break;
+                case StatusEffectType.CritChanceUp:
+                    possibilityPool.AddModifier(StatusChanceType.Critical, -effect.magnitude / 100f);
+                    activeStatusEffects.RemoveAt(i);
+                    break;
+                case StatusEffectType.CritDamageUp:
+                    possibilityPool.AddCriticalMultiplierBonus(-effect.magnitude / 100f);
+                    activeStatusEffects.RemoveAt(i);
+                    break;
+                case StatusEffectType.Stun:
+                    activeStatusEffects.RemoveAt(i);
+                    break;
+            }
+        }
+
+        StatusEffectsChanged?.Invoke();
+    }
+
     private void TryApplyNerveRotVialDebuff(Character source)
     {
         if (source == null || !(source is Player playerSource)) return;

--- a/LlmGame/Assets/Script/CharacterCombatHandler.cs
+++ b/LlmGame/Assets/Script/CharacterCombatHandler.cs
@@ -261,6 +261,7 @@ public class CharacterCombatHandler : MonoBehaviour
         }
 
         Debug.Log("EndEnemyTurn");
+        battleManager.currentActingCharacter?.ClearEndTurnEffects();
         battleManager.turnCount++;
         battleManager.isActionPhase = false;
         battleManager.currentActingCharacter = null;

--- a/LlmGame/Assets/Script/ChatAI.cs
+++ b/LlmGame/Assets/Script/ChatAI.cs
@@ -214,8 +214,9 @@ public class ChatAI : MonoBehaviour
             baseFeasibilityDesc = "Boss skill";
             basePotentialDesc = "No damage";
             baseEffect = action != null ? action.actionName : "";
-            baseEffectDesc = "";
+            baseEffectDesc = bossBehavior.GetSkillDescription(action);
 
+            AppendResponse($"{enemy.characterName} uses {baseEffect}: {baseEffectDesc}");
             AppendResponse(FormatResult());
             yield break;
         }
@@ -327,6 +328,8 @@ public class ChatAI : MonoBehaviour
     {
         if (responseText == null) return;
 
+        message = message.Replace("\\n", "\n");
+
         if (!string.IsNullOrEmpty(responseText.text))
             responseText.text += "\n";
 
@@ -341,16 +344,16 @@ public class ChatAI : MonoBehaviour
         string feasLine = $"Feasibility: {baseFeasibility}";
         if (SettingsManager.Instance == null || SettingsManager.Instance.showFeasibilityDesc)
             feasLine += $" ({baseFeasibilityDesc})";
-        feasLine += "\\n";
+        feasLine += "\n";
 
         string potLine = $"Potential: {basePotential}";
         if (SettingsManager.Instance == null || SettingsManager.Instance.showPotentialDesc)
             potLine += $" ({basePotentialDesc})";
-        potLine += "\\n";
+        potLine += "\n";
 
         string effectLine = $"Effect: {baseEffect}";
 
-        return $"\\n<color=#00ffcc><b>Result:</b></color>\\n" + feasLine + potLine + effectLine;
+        return $"\n<color=#00ffcc><b>Result:</b></color>\n" + feasLine + potLine + effectLine;
     }
 
     public string EscapeJsonString(string str)

--- a/LlmGame/Assets/Script/ConsumeTurnItem.cs
+++ b/LlmGame/Assets/Script/ConsumeTurnItem.cs
@@ -31,58 +31,98 @@ public class ConsumeTurnItem : Item
         {
             case "Reinforced Plating":
                 target.defense += 10;
-                battleManager.battleLog.Add($"{user.characterName} used {itemName} on {target.characterName}, increasing defense by 10.");
+                {
+                    string msg = $"{user.characterName} used {itemName} on {target.characterName}, increasing defense by 10.";
+                    battleManager.battleLog.Add(msg);
+                    battleManager.chatAI.AppendResponse(msg);
+                }
                 break;
 
             case "HP Booster":
                 target.maxHP = Mathf.RoundToInt(target.maxHP * 1.2f);
                 target.currentHP = Mathf.RoundToInt(target.currentHP * 1.2f);
                 if (target.currentHP > target.maxHP) target.currentHP = target.maxHP;
-                battleManager.battleLog.Add($"{user.characterName} boosted {target.characterName}'s HP by 20%.");
+                {
+                    string msg = $"{user.characterName} boosted {target.characterName}'s HP by 20%.";
+                    battleManager.battleLog.Add(msg);
+                    battleManager.chatAI.AppendResponse(msg);
+                }
                 break;
 
             case "MP Cell":
                 target.maxMP = Mathf.RoundToInt(target.maxMP * 1.2f);
                 target.currentMP = Mathf.RoundToInt(target.currentMP * 1.2f);
                 if (target.currentMP > target.maxMP) target.currentMP = target.maxMP;
-                battleManager.battleLog.Add($"{user.characterName} boosted {target.characterName}'s MP by 20%.");
+                {
+                    string msg = $"{user.characterName} boosted {target.characterName}'s MP by 20%.";
+                    battleManager.battleLog.Add(msg);
+                    battleManager.chatAI.AppendResponse(msg);
+                }
                 break;
 
             case "Bandage":
                 target.activeStatusEffects.RemoveAll(e => e.effectType == StatusEffectType.Bleed && !e.isPermanent);
-                battleManager.battleLog.Add($"{user.characterName} bandaged {target.characterName}, removing bleeding.");
+                {
+                    string msg = $"{user.characterName} bandaged {target.characterName}, removing bleeding.";
+                    battleManager.battleLog.Add(msg);
+                    battleManager.chatAI.AppendResponse(msg);
+                }
                 break;
 
             case "Antidote":
                 target.activeStatusEffects.RemoveAll(e => e.effectType == StatusEffectType.Poison && !e.isPermanent);
-                battleManager.battleLog.Add($"{user.characterName} cured {target.characterName}'s poison.");
+                {
+                    string msg = $"{user.characterName} cured {target.characterName}'s poison.";
+                    battleManager.battleLog.Add(msg);
+                    battleManager.chatAI.AppendResponse(msg);
+                }
                 break;
 
             case "Shield Battery":
                 target.currentshield = Mathf.Min(target.maxShield, target.currentshield + 20);
-                battleManager.battleLog.Add($"{user.characterName} restored 20 shield to {target.characterName}.");
+                {
+                    string msg = $"{user.characterName} restored 20 shield to {target.characterName}.";
+                    battleManager.battleLog.Add(msg);
+                    battleManager.chatAI.AppendResponse(msg);
+                }
                 break;
 
             case "Focus Tonic":
                 target.ApplyStatusEffect(new TurnStatusEffect(StatusEffectType.CritChanceUp, 2, 25));
-                battleManager.battleLog.Add($"{user.characterName} increased {target.characterName}'s critical chance.");
+                {
+                    string msg = $"{user.characterName} increased {target.characterName}'s critical chance.";
+                    battleManager.battleLog.Add(msg);
+                    battleManager.chatAI.AppendResponse(msg);
+                }
                 break;
 
             case "Adrenaline Shot":
                 int heal25 = Mathf.RoundToInt(target.maxHP * 0.25f);
                 target.currentHP = Mathf.Min(target.maxHP, target.currentHP + heal25);
-                battleManager.battleLog.Add($"{user.characterName} healed {target.characterName} for {heal25} HP.");
+                {
+                    string msg = $"{user.characterName} healed {target.characterName} for {heal25} HP.";
+                    battleManager.battleLog.Add(msg);
+                    battleManager.chatAI.AppendResponse(msg);
+                }
                 break;
 
             case "Soul Patch":
                 int heal50 = Mathf.RoundToInt(target.maxHP * 0.5f);
                 target.currentHP = Mathf.Min(target.maxHP, target.currentHP + heal50);
-                battleManager.battleLog.Add($"{user.characterName} healed {target.characterName} for {heal50} HP.");
+                {
+                    string msg = $"{user.characterName} healed {target.characterName} for {heal50} HP.";
+                    battleManager.battleLog.Add(msg);
+                    battleManager.chatAI.AppendResponse(msg);
+                }
                 break;
 
             case "Overdrive Chip":
                 target.mpRegenPerTurn += 10;
-                battleManager.battleLog.Add($"{user.characterName} enhanced {target.characterName}'s MP regeneration by 10 per turn.");
+                {
+                    string msg = $"{user.characterName} enhanced {target.characterName}'s MP regeneration by 10 per turn.";
+                    battleManager.battleLog.Add(msg);
+                    battleManager.chatAI.AppendResponse(msg);
+                }
                 break;
 
             default:

--- a/LlmGame/Assets/Script/DamageModifierSkill.cs
+++ b/LlmGame/Assets/Script/DamageModifierSkill.cs
@@ -50,6 +50,7 @@ public class DamageModifierSkill : ScriptableObject
 
         user.currentMP -= mpCost;
         Debug.Log($"{user.characterName} uses {skillName} on {target.characterName}");
+        battleManager.chatAI.AppendResponse($"{user.characterName} uses {skillName}: {skillDescription}");
 
         // Apply specific skill effects
         if (skillName == "Radiant Collapse")


### PR DESCRIPTION
## Summary
- fix response text so newline characters render correctly
- log consumable item and damage modifier skill usage in battle responses
- show boss skill descriptions and clear turn-based buffs at turn end

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad51dacc1c8322a049a4cfbaabd952