### PR TITLE
Add basic cutscene flow

### DIFF
--- a/LlmGame/Assets/Script/BattleManager.cs
+++ b/LlmGame/Assets/Script/BattleManager.cs
@@ -531,7 +531,16 @@ public class BattleManager : MonoBehaviour
         if (!anyEnemyAlive)
         {
             Debug.Log("All Enemies Defeated!");
-            if (!rewardShown)
+            bool bossBattle = enemies.Any(e => e.archetype == EnemyArchetype.Boss);
+            if (bossBattle)
+            {
+                if (!rewardShown)
+                {
+                    CutsceneManager.Instance?.PlayEndGameCutscene();
+                    rewardShown = true;
+                }
+            }
+            else if (!rewardShown)
             {
                 int moneyGain = player.money - startMoney;
                 int itemGain = (player.inventoryItems != null ? player.inventoryItems.Count : 0) - startItemCount;

--- a/LlmGame/Assets/Script/Cutscene/CutsceneManager.cs
+++ b/LlmGame/Assets/Script/Cutscene/CutsceneManager.cs
@@ -1,0 +1,38 @@
+using UnityEngine;
+using UnityEngine.Playables;
+
+public class CutsceneManager : MonoBehaviour
+{
+    public static CutsceneManager Instance { get; private set; }
+
+    [Header("Cutscenes")]
+    [SerializeField] private PlayableDirector startGameCutscene;
+    [SerializeField] private PlayableDirector endGameCutscene;
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+    }
+
+    public void PlayStartGameCutscene()
+    {
+        if (startGameCutscene != null)
+        {
+            startGameCutscene.Play();
+        }
+    }
+
+    public void PlayEndGameCutscene()
+    {
+        if (endGameCutscene != null)
+        {
+            endGameCutscene.Play();
+        }
+    }
+}

--- a/LlmGame/Assets/Script/Cutscene/StartGameCutscene.cs
+++ b/LlmGame/Assets/Script/Cutscene/StartGameCutscene.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+public class StartGameCutscene : MonoBehaviour
+{
+    private void Start()
+    {
+        CutsceneManager.Instance?.PlayStartGameCutscene();
+    }
+}


### PR DESCRIPTION
## Summary
- add `CutsceneManager` to play start and end game sequences
- trigger start cutscene on game start
- play special cutscene when boss battle ends

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad522825188322a8284fb7e0bac119