### PR TITLE
fix status effect turn handling and hide damage descriptions

### DIFF
--- a/LlmGame/Assets/Script/BattleManager.cs
+++ b/LlmGame/Assets/Script/BattleManager.cs
@@ -196,6 +196,7 @@ public class BattleManager : MonoBehaviour
                 foreach (var listener in character.GetComponentsInChildren<ITurnListener>())
                     listener.OnTurnStart(character);
 
+                bool wasStunned = character.HasStatusEffect(StatusEffectType.Stun);
                 string statusLog = character.ProcessStatusEffects();
                 if (!string.IsNullOrEmpty(statusLog))
                 {
@@ -205,7 +206,7 @@ public class BattleManager : MonoBehaviour
                 foreach (var listener in character.GetComponentsInChildren<ITurnListener>())
                     listener.OnTurnEnd(character);
 
-                if (character.HasStatusEffect(StatusEffectType.Stun))
+                if (wasStunned)
                 {
                     Debug.Log($"{character.characterName} is stunned and skips their turn.");
                     StartCoroutine(SkipTurn(character));

--- a/LlmGame/Assets/Script/Character.cs
+++ b/LlmGame/Assets/Script/Character.cs
@@ -617,38 +617,9 @@ public class Character : MonoBehaviour
 
     public void ClearEndTurnEffects()
     {
-        for (int i = activeStatusEffects.Count - 1; i >= 0; i--)
-        {
-            TurnStatusEffect effect = activeStatusEffects[i];
-            if (effect.isPermanent) continue;
-            switch (effect.effectType)
-            {
-                case StatusEffectType.AttackUp:
-                    attack -= effect.magnitude;
-                    activeStatusEffects.RemoveAt(i);
-                    break;
-                case StatusEffectType.DefenseUp:
-                    defense -= effect.magnitude;
-                    activeStatusEffects.RemoveAt(i);
-                    break;
-                case StatusEffectType.SpeedUp:
-                    speed -= effect.magnitude;
-                    activeStatusEffects.RemoveAt(i);
-                    break;
-                case StatusEffectType.CritChanceUp:
-                    possibilityPool.AddModifier(StatusChanceType.Critical, -effect.magnitude / 100f);
-                    activeStatusEffects.RemoveAt(i);
-                    break;
-                case StatusEffectType.CritDamageUp:
-                    possibilityPool.AddCriticalMultiplierBonus(-effect.magnitude / 100f);
-                    activeStatusEffects.RemoveAt(i);
-                    break;
-                case StatusEffectType.Stun:
-                    activeStatusEffects.RemoveAt(i);
-                    break;
-            }
-        }
-
+        // Buff and stun effects now persist across turns and expire naturally
+        // via ProcessStatusEffects. This method only triggers the update
+        // event so UI elements can refresh after a turn ends.
         StatusEffectsChanged?.Invoke();
     }
 

--- a/LlmGame/Assets/Script/ChatAI.cs
+++ b/LlmGame/Assets/Script/ChatAI.cs
@@ -342,12 +342,12 @@ public class ChatAI : MonoBehaviour
     private string FormatResult()
     {
         string feasLine = $"Feasibility: {baseFeasibility}";
-        if (SettingsManager.Instance == null || SettingsManager.Instance.showFeasibilityDesc)
+        if (SettingsManager.Instance != null && SettingsManager.Instance.showFeasibilityDesc)
             feasLine += $" ({baseFeasibilityDesc})";
         feasLine += "\n";
 
         string potLine = $"Potential: {basePotential}";
-        if (SettingsManager.Instance == null || SettingsManager.Instance.showPotentialDesc)
+        if (SettingsManager.Instance != null && SettingsManager.Instance.showPotentialDesc)
             potLine += $" ({basePotentialDesc})";
         potLine += "\n";
 


### PR DESCRIPTION
## Summary
- hide feasibility and potential descriptions unless enabled in settings
- ensure stun and other status effects tick down naturally between turns

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*


------
https://chatgpt.com/codex/tasks/task_e_68ad5776c5048322a4c2e14b63d1eae0