### PR TITLE
Add enemy action descriptions and per-node MP gain

### DIFF
--- a/LlmGame/Assets/Script/BattleManager.cs
+++ b/LlmGame/Assets/Script/BattleManager.cs
@@ -685,6 +685,8 @@ public class BattleManager : MonoBehaviour
     private IEnumerator ReturnToMapAfterDelay()
     {
         yield return new WaitForSeconds(2f);
+        PlayerData.Instance?.GainMPOnNodeExit(player);
+        PlayerData.Instance?.SavePlayer(player);
         SceneManager.LoadScene("MapGenerate");
     }
 }

--- a/LlmGame/Assets/Script/CharacterActionData.cs
+++ b/LlmGame/Assets/Script/CharacterActionData.cs
@@ -5,6 +5,8 @@ using UnityEngine;
 public class CharacterActionData : ScriptableObject
 {
     public string actionName;
+    [TextArea]
+    public string description;
     public string animationTrigger;
 
     [Tooltip("Number of turns before this action resolves. 0 means immediate.")]

--- a/LlmGame/Assets/Script/DefaultPlayerConfig.cs
+++ b/LlmGame/Assets/Script/DefaultPlayerConfig.cs
@@ -17,7 +17,7 @@ public class DefaultPlayerConfig : ScriptableObject
     public int startMoney = 0;
     public int startShield = 0; // usually 0
     public bool startWithFullHP = true;
-    public bool startWithFullMP = true;
+    public bool startWithFullMP = false;
 
     [Header("Starting Inventory & Equipment")]
     public List<Item> startingInventory = new List<Item>();

--- a/LlmGame/Assets/Script/MysteryEventUI.cs
+++ b/LlmGame/Assets/Script/MysteryEventUI.cs
@@ -192,6 +192,10 @@ public class MysteryEventUI : MonoBehaviour
                 sceneToLoad = "BattleScene02";
             }
 
+            var player = FindObjectOfType<Player>();
+            PlayerData.Instance?.GainMPOnNodeExit(player);
+            PlayerData.Instance?.SavePlayer(player);
+
             LoadScene(sceneToLoad);
         }
     }

--- a/LlmGame/Assets/Script/PlayerData.cs
+++ b/LlmGame/Assets/Script/PlayerData.cs
@@ -22,6 +22,9 @@ public class PlayerData : MonoBehaviour
     public int currentShield;
     public int money;
 
+    [Header("Progression")]
+    public int mpGainOnNodeExit = 10;
+
     // Inventory and equipment
     public List<Item> inventoryItems = new List<Item>();
     public List<ArmorData> inventoryArmors = new List<ArmorData>();
@@ -69,7 +72,7 @@ public class PlayerData : MonoBehaviour
 
         // Current values
         currentHP = config ? (config.startWithFullHP ? maxHP : Mathf.Min(currentHP, maxHP)) : 0;
-        currentMP = config ? (config.startWithFullMP ? maxMP : Mathf.Min(currentMP, maxMP)) : 0;
+        currentMP = config && config.startWithFullMP ? maxMP : 0;
         currentShield = config ? Mathf.Clamp(config.startShield, 0, maxShield) : 0;
         money = config ? config.startMoney : 0;
 
@@ -127,6 +130,15 @@ public class PlayerData : MonoBehaviour
         }
 
         initialized = true;
+    }
+
+    public void GainMPOnNodeExit(Player player = null)
+    {
+        int before = player != null ? player.currentMP : currentMP;
+        int after = Mathf.Min(maxMP, before + mpGainOnNodeExit);
+        if (player != null) player.currentMP = after;
+        currentMP = after;
+        Debug.Log($"Gained {after - before} MP (MP: {before} -> {after})");
     }
 
     /// <summary>

--- a/LlmGame/Assets/Script/PromptBuilder.cs
+++ b/LlmGame/Assets/Script/PromptBuilder.cs
@@ -89,6 +89,8 @@ public static class PromptBuilder
     public static string BuildEnemyPrompt(BattleManager battleManager, Character enemy, Character target, CharacterActionData action, string effect)
     {
         string proposedAction = action.actionName;
+        if (!string.IsNullOrEmpty(action.description))
+            proposedAction += $" - {action.description}";
         string history = GetBattleHistory(battleManager);
 
         // Detect selected parts in player based on enemy's action

--- a/LlmGame/Assets/Script/ShopSceneController.cs
+++ b/LlmGame/Assets/Script/ShopSceneController.cs
@@ -308,7 +308,10 @@ public class ShopSceneController : MonoBehaviour
         }
 
         if (PlayerData.Instance != null && player != null)
+        {
+            PlayerData.Instance.GainMPOnNodeExit(player);
             PlayerData.Instance.SavePlayer(player);
+        }
 
         Debug.Log($"[Shop] Loading next scene: {nextSceneName}");
         SceneManager.LoadScene(nextSceneName);

--- a/LlmGame/Assets/Script/UI/RestEventUI.cs
+++ b/LlmGame/Assets/Script/UI/RestEventUI.cs
@@ -208,6 +208,10 @@ public class RestEventUI : MonoBehaviour
                 sceneToLoad = "BattleScene02";
             }
 
+            var player = FindObjectOfType<Player>();
+            PlayerData.Instance?.GainMPOnNodeExit(player);
+            PlayerData.Instance?.SavePlayer(player);
+
             LoadScene(sceneToLoad);
         }
     }

--- a/LlmGame/Assets/Script/UI/TreasureUIController.cs
+++ b/LlmGame/Assets/Script/UI/TreasureUIController.cs
@@ -98,6 +98,9 @@ public class TreasureUIController : MonoBehaviour
 
     private void OnClick_LoadMapGenerate()
     {
+        var player = FindObjectOfType<Player>();
+        PlayerData.Instance?.GainMPOnNodeExit(player);
+        PlayerData.Instance?.SavePlayer(player);
         SceneManager.LoadScene("MapGenerate");
     }
 }


### PR DESCRIPTION
## Summary
- allow enemy actions to include text descriptions and include them in AI prompts
- start players with zero MP and add MP gain when leaving any node
- expose configurable MP gain per node in PlayerData

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68afefa79130832297de421cdf366933