### PR TITLE
Implement enemy currency rewards and rebalance mystery node economy

### DIFF
--- a/LlmGame/Assets/Script/BattleManager.cs
+++ b/LlmGame/Assets/Script/BattleManager.cs
@@ -532,13 +532,25 @@ public class BattleManager : MonoBehaviour
     private void GrantBattleRewards()
     {
         NodeType nodeType = PlayerData.Instance != null ? PlayerData.Instance.nextNodeType : NodeType.MinorEnemy;
-        int credits = 0;
+        EnemyDifficulty difficulty = PlayerData.Instance != null ? PlayerData.Instance.nextEnemyDifficulty : EnemyDifficulty.Normal;
+
+        int baseCredits = enemies.Sum(e => e.currencyReward);
+        float multiplier = 1f;
+        switch (difficulty)
+        {
+            case EnemyDifficulty.Easy:
+                multiplier = 0.90f;
+                break;
+            case EnemyDifficulty.Hard:
+                multiplier = 1.15f;
+                break;
+        }
+        int credits = Mathf.RoundToInt(baseCredits * multiplier);
+        player.money += credits;
 
         switch (nodeType)
         {
             case NodeType.MinorEnemy:
-                credits = Random.Range(10, 21);
-                player.money += credits;
                 if (storeSystem != null && Random.value < 0.2f)
                 {
                     var passive = GetRandomPassive(ItemRarity.Common);
@@ -548,8 +560,6 @@ public class BattleManager : MonoBehaviour
                 break;
 
             case NodeType.EliteEnemy:
-                credits = Random.Range(20, 51);
-                player.money += credits;
                 if (storeSystem != null)
                 {
                     ScriptableObject drop;
@@ -560,11 +570,6 @@ public class BattleManager : MonoBehaviour
                     if (drop != null)
                         storeSystem.BuyItem(player, drop);
                 }
-                break;
-
-            default:
-                credits = Random.Range(5, 11);
-                player.money += credits;
                 break;
         }
 

--- a/LlmGame/Assets/Script/Enemy.cs
+++ b/LlmGame/Assets/Script/Enemy.cs
@@ -14,6 +14,10 @@ public class Enemy : Character
     [Header("Enemy Info")]
     public EnemyArchetype archetype;
 
+    [Header("Rewards")]
+    [Tooltip("Base currency granted when this enemy is defeated.")]
+    public int currencyReward = 10;
+
     [Header("Action")]
     public List<string> actions;
 

--- a/LlmGame/Assets/Script/MysterySceneEventHandler.cs
+++ b/LlmGame/Assets/Script/MysterySceneEventHandler.cs
@@ -13,8 +13,8 @@ public class MysterySceneEventHandler : MonoBehaviour
 
     [Header("Config")]
     public int smallCreditCost = 50;
-    public int droneMpCost = 20;
-    public int hackMpCost = 20;
+    public int droneMpCost = 30; // ≈45 credits of value
+    public int hackMpCost = 30;  // ≈45 credits of value
     public PassiveItemData msgNoodleItem;
     public List<Weapon> weaponPool = new();
 
@@ -168,7 +168,7 @@ public class MysterySceneEventHandler : MonoBehaviour
         ChangeMP(-droneMpCost);
         if (Random.value < 0.5f)
         {
-            int credits = Random.Range(5, 16);
+            int credits = Random.Range(10, 21);
             ChangeMoney(credits);
             Log($"Drone revealed hidden credits: +{credits}");
         }
@@ -199,7 +199,7 @@ public class MysterySceneEventHandler : MonoBehaviour
             }
             else
             {
-                int credits = Random.Range(5, 16);
+                int credits = Random.Range(10, 21);
                 ChangeMoney(credits);
                 Log($"Cloaked man: slipped you credits (+{credits}).");
             }
@@ -225,7 +225,7 @@ public class MysterySceneEventHandler : MonoBehaviour
     {
         if (Random.value < 0.5f)
         {
-            int credits = Random.Range(10, 21);
+            int credits = Random.Range(15, 31);
             ChangeMoney(credits);
             GrantRandomItem(ItemRarity.Rare);
             Log($"Intimidation succeeded: stole +{credits} credits and rare loot.");
@@ -290,7 +290,7 @@ public class MysterySceneEventHandler : MonoBehaviour
         {
             if (Random.value < 0.5f)
             {
-                int credits = Random.Range(20, 41);
+                int credits = Random.Range(30, 51);
                 ChangeMoney(credits);
                 Log($"Pickpocket succeeded: +{credits} credits.");
             }


### PR DESCRIPTION
## Summary
- Add per-enemy currency rewards and apply difficulty multipliers to battle payouts
- Raise drone and hack MP costs and standardize mystery node cash drops

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68affd982cc48322a5a0e88eb882d954