### PR TITLE
Add full-stack developer exam template

### DIFF
--- a/DeveloperExamTemplate/api/tasks.http
+++ b/DeveloperExamTemplate/api/tasks.http
@@ -1,0 +1,15 @@
+### ตรวจสอบสถานะของ API
+GET http://localhost:4000/api/health
+
+### ดึงรายการงานทั้งหมด
+GET http://localhost:4000/api/tasks
+Accept: application/json
+
+### สร้างงานใหม่
+POST http://localhost:4000/api/tasks
+Content-Type: application/json
+
+{
+  "title": "ทดสอบ API",
+  "description": "ลองยิงคำขอ POST เพื่อสร้างงานใหม่"
+}

--- a/DeveloperExamTemplate/backend/.env.example
+++ b/DeveloperExamTemplate/backend/.env.example
@@ -1,0 +1,6 @@
+PORT=4000
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=developer_exam
+DB_USER=postgres
+DB_PASSWORD=postgres

--- a/DeveloperExamTemplate/backend/controllers/taskController.js
+++ b/DeveloperExamTemplate/backend/controllers/taskController.js
@@ -1,0 +1,34 @@
+import Joi from 'joi';
+import { createTask, getAllTasks } from '../models/taskModel.js';
+
+// สร้างสคีมาสำหรับตรวจสอบข้อมูลที่ผู้ใช้ส่งเข้ามา
+const taskSchema = Joi.object({
+  title: Joi.string().min(3).max(100).required(),
+  description: Joi.string().min(5).max(500).required()
+});
+
+// Controller สำหรับดึงข้อมูลรายการงานทั้งหมด
+export const handleGetTasks = async (_req, res, next) => {
+  try {
+    const tasks = await getAllTasks();
+    res.json(tasks);
+  } catch (error) {
+    next(error);
+  }
+};
+
+// Controller สำหรับบันทึกงานใหม่ลงฐานข้อมูล
+export const handleCreateTask = async (req, res, next) => {
+  try {
+    const { error, value } = taskSchema.validate(req.body);
+    if (error) {
+      // ตอบกลับด้วยสถานะ 400 เพื่อสื่อว่าข้อมูลไม่ถูกต้อง
+      return res.status(400).json({ message: error.message });
+    }
+
+    const newTask = await createTask(value);
+    res.status(201).json(newTask);
+  } catch (error) {
+    next(error);
+  }
+};

--- a/DeveloperExamTemplate/backend/models/db.js
+++ b/DeveloperExamTemplate/backend/models/db.js
@@ -1,0 +1,25 @@
+import pkg from 'pg';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const { Pool } = pkg;
+
+// กำหนดค่าการเชื่อมต่อฐานข้อมูลจากตัวแปรสภาพแวดล้อมเพื่อความยืดหยุ่น
+export const pool = new Pool({
+  host: process.env.DB_HOST ?? 'localhost',
+  port: Number(process.env.DB_PORT ?? 5432),
+  database: process.env.DB_NAME ?? 'developer_exam',
+  user: process.env.DB_USER ?? 'postgres',
+  password: process.env.DB_PASSWORD ?? 'postgres'
+});
+
+// ฟังก์ชันสำหรับทดสอบการเชื่อมต่อฐานข้อมูล
+export const verifyConnection = async () => {
+  try {
+    await pool.query('SELECT 1');
+    console.log('Database connection established successfully.');
+  } catch (error) {
+    console.error('Database connection failed:', error.message);
+  }
+};

--- a/DeveloperExamTemplate/backend/models/taskModel.js
+++ b/DeveloperExamTemplate/backend/models/taskModel.js
@@ -1,0 +1,16 @@
+import { pool } from './db.js';
+
+// ดึงรายการงานทั้งหมดจากฐานข้อมูลเพื่อใช้แสดงใน Front-end
+export const getAllTasks = async () => {
+  const result = await pool.query('SELECT id, title, description, status FROM tasks ORDER BY id');
+  return result.rows;
+};
+
+// เพิ่มงานใหม่และคืนค่าข้อมูลที่ถูกบันทึกจริงในฐานข้อมูล
+export const createTask = async ({ title, description }) => {
+  const result = await pool.query(
+    'INSERT INTO tasks (title, description) VALUES ($1, $2) RETURNING id, title, description, status',
+    [title, description]
+  );
+  return result.rows[0];
+};

--- a/DeveloperExamTemplate/backend/package.json
+++ b/DeveloperExamTemplate/backend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "developer-exam-backend",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "nodemon server.js",
+    "start": "node server.js",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "joi": "^17.12.0",
+    "pg": "^8.11.3"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.3",
+    "supertest": "^6.3.4",
+    "vitest": "^1.3.0"
+  }
+}

--- a/DeveloperExamTemplate/backend/routes/taskRoutes.js
+++ b/DeveloperExamTemplate/backend/routes/taskRoutes.js
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import { handleCreateTask, handleGetTasks } from '../controllers/taskController.js';
+
+const router = Router();
+
+// GET /api/tasks - ดึงรายการงานทั้งหมดจากฐานข้อมูล
+router.get('/', handleGetTasks);
+
+// POST /api/tasks - เพิ่มงานใหม่ตามข้อมูลที่ส่งมาจาก Front-end
+router.post('/', handleCreateTask);
+
+export default router;

--- a/DeveloperExamTemplate/backend/server.js
+++ b/DeveloperExamTemplate/backend/server.js
@@ -1,0 +1,31 @@
+import express from 'express';
+import cors from 'cors';
+import dotenv from 'dotenv';
+import taskRoutes from './routes/taskRoutes.js';
+
+// โหลดไฟล์ .env เพื่อให้ผู้เข้าสอบสามารถตั้งค่าพอร์ตและการเชื่อมต่อฐานข้อมูลได้ง่าย
+dotenv.config();
+
+const app = express();
+
+// กำหนดค่าเริ่มต้นของพอร์ตให้สามารถ override ผ่าน ENV ได้
+const PORT = process.env.PORT ?? 4000;
+
+// เปิดใช้งาน CORS เพื่อให้ Front-end เข้าถึง API ได้จากโดเมนอื่น
+app.use(cors());
+
+// รองรับ request body ที่เป็น JSON ซึ่งเป็นรูปแบบที่ใช้บ่อยที่สุด
+app.use(express.json());
+
+// รวมเส้นทางของโมดูลงาน (Task) และสามารถเพิ่มโมดูลอื่น ๆ ได้ในอนาคต
+app.use('/api/tasks', taskRoutes);
+
+// health check endpoint สำหรับตรวจสอบสถานะของเซิร์ฟเวอร์อย่างรวดเร็ว
+app.get('/api/health', (_, res) => {
+  res.json({ status: 'ok' });
+});
+
+// เริ่มต้นเซิร์ฟเวอร์และแสดงข้อความช่วย Debug
+app.listen(PORT, () => {
+  console.log(`Backend server is running on port ${PORT}`);
+});

--- a/DeveloperExamTemplate/database/schema.sql
+++ b/DeveloperExamTemplate/database/schema.sql
@@ -1,0 +1,8 @@
+-- สคริปต์สร้างฐานข้อมูลสำหรับการสอบ Developer
+CREATE TABLE IF NOT EXISTS tasks (
+    id SERIAL PRIMARY KEY,
+    title VARCHAR(100) NOT NULL,
+    description TEXT NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'pending',
+    created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW()
+);

--- a/DeveloperExamTemplate/database/seed.sql
+++ b/DeveloperExamTemplate/database/seed.sql
@@ -1,0 +1,6 @@
+-- ข้อมูลตัวอย่างเพื่อใช้ในการทดสอบระบบอย่างรวดเร็ว
+INSERT INTO tasks (title, description, status)
+VALUES
+    ('ออกแบบหน้า Landing Page', 'ออกแบบ UI/UX ของหน้าแรกให้เสร็จพร้อมใช้', 'in_progress'),
+    ('พัฒนา Endpoint /api/tasks', 'สร้าง REST API สำหรับงาน', 'done'),
+    ('เตรียม Test Coverage', 'วางแผนและเขียน unit test สำหรับ backend', 'pending');

--- a/DeveloperExamTemplate/frontend/index.html
+++ b/DeveloperExamTemplate/frontend/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Developer Exam Front-end Template</title>
+    <!-- Candidates can add additional stylesheets here when extending the template. -->
+  </head>
+  <body>
+    <!-- The React application is mounted into this single root element. -->
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/DeveloperExamTemplate/frontend/package.json
+++ b/DeveloperExamTemplate/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "developer-exam-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "axios": "^1.6.8"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^5.0.0",
+    "vitest": "^1.3.0"
+  }
+}

--- a/DeveloperExamTemplate/frontend/src/App.jsx
+++ b/DeveloperExamTemplate/frontend/src/App.jsx
@@ -1,0 +1,73 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import TaskList from './components/TaskList.jsx';
+import TaskForm from './components/TaskForm.jsx';
+
+// The API base URL is isolated so candidates can change it for different environments.
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:4000/api';
+
+const App = () => {
+  // Local state keeps the tasks retrieved from the backend API.
+  const [tasks, setTasks] = useState([]);
+  // Track whether the template is currently loading data from the backend.
+  const [isLoading, setIsLoading] = useState(false);
+  // Store any error messages to help candidates debug integration problems quickly.
+  const [error, setError] = useState(null);
+
+  // Fetch tasks from the backend when the component mounts.
+  useEffect(() => {
+    const fetchTasks = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const response = await axios.get(`${API_BASE_URL}/tasks`);
+        setTasks(response.data);
+      } catch (err) {
+        // Expose only the relevant information so that candidates can display it in the UI.
+        setError(err.response?.data?.message ?? 'ไม่สามารถเชื่อมต่อ API ได้');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchTasks();
+  }, []);
+
+  // Handle task creation by delegating to the backend API.
+  const handleCreateTask = async (taskData) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await axios.post(`${API_BASE_URL}/tasks`, taskData);
+      setTasks((current) => [...current, response.data]);
+    } catch (err) {
+      setError(err.response?.data?.message ?? 'ไม่สามารถสร้างงานใหม่ได้');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="app-container">
+      <header>
+        <h1>Developer Exam Front-end Template</h1>
+        <p>
+          ใช้โครงร่างนี้เพื่อแสดงทักษะด้าน Front-end โดยการเชื่อมต่อกับ Back-end,
+          จัดการสถานะ และออกแบบ UI
+        </p>
+      </header>
+
+      {/* TaskForm จะรับผิดชอบการสร้างงานใหม่และแจ้งผลกลับมาที่คอมโพเนนต์หลัก */}
+      <TaskForm onCreateTask={handleCreateTask} isSubmitting={isLoading} />
+
+      {/* แสดงสถานะการโหลดและข้อผิดพลาดเพื่อสื่อสารกับผู้ใช้ได้ชัดเจน */}
+      {isLoading && <p>กำลังโหลดข้อมูล...</p>}
+      {error && <p className="error">{error}</p>}
+
+      {/* ส่งรายการงานไปยังคอมโพเนนต์ย่อยเพื่อการแยกความรับผิดชอบ */}
+      <TaskList tasks={tasks} />
+    </div>
+  );
+};
+
+export default App;

--- a/DeveloperExamTemplate/frontend/src/components/TaskForm.jsx
+++ b/DeveloperExamTemplate/frontend/src/components/TaskForm.jsx
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+
+// ฟอร์มนี้ใช้เก็บข้อมูลพื้นฐานของงานใหม่และแจ้งกลับให้คอมโพเนนต์หลัก
+const TaskForm = ({ onCreateTask, isSubmitting }) => {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    // ส่งข้อมูลขึ้นไปยัง App เพื่อเรียกใช้งาน API
+    onCreateTask({ title, description });
+    setTitle('');
+    setDescription('');
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <h2>สร้างงานใหม่</h2>
+      <label>
+        หัวข้องาน
+        <input
+          value={title}
+          onChange={(event) => setTitle(event.target.value)}
+          placeholder="เช่น ออกแบบหน้า Dashboard"
+          required
+        />
+      </label>
+
+      <label>
+        รายละเอียด
+        <textarea
+          value={description}
+          onChange={(event) => setDescription(event.target.value)}
+          placeholder="อธิบายรายละเอียดงานที่จะทำ"
+          rows={4}
+          required
+        />
+      </label>
+
+      <button type="submit" disabled={isSubmitting}>
+        {isSubmitting ? 'กำลังบันทึก...' : 'เพิ่มงาน'}
+      </button>
+    </form>
+  );
+};
+
+export default TaskForm;

--- a/DeveloperExamTemplate/frontend/src/components/TaskList.jsx
+++ b/DeveloperExamTemplate/frontend/src/components/TaskList.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+// คอมโพเนนต์รับรายการงานทั้งหมดและแสดงผลเป็นลิสต์อย่างเรียบง่าย
+const TaskList = ({ tasks }) => {
+  if (!tasks.length) {
+    // เมื่อไม่มีงานให้แสดงข้อความอธิบายอย่างชัดเจน
+    return <p>ยังไม่มีงานที่ต้องทำ ลองเพิ่มงานใหม่ดูนะ!</p>;
+  }
+
+  return (
+    <section>
+      <h2>รายการงาน</h2>
+      <ul>
+        {tasks.map((task) => (
+          // ใช้ค่า id ที่ได้จากฐานข้อมูลเป็น key เพื่อช่วย React จัดการ DOM
+          <li key={task.id}>
+            <h3>{task.title}</h3>
+            <p>{task.description}</p>
+            <span className="status">สถานะ: {task.status}</span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+};
+
+export default TaskList;

--- a/DeveloperExamTemplate/frontend/src/main.jsx
+++ b/DeveloperExamTemplate/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+
+// The entry point wires up the top-level React component with the DOM.
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/DeveloperExamTemplate/frontend/vite.config.js
+++ b/DeveloperExamTemplate/frontend/vite.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// Exporting the Vite configuration that powers the React development server.
+// This keeps the setup minimal for candidates while allowing modern tooling features.
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    // The port is fixed so the backend can reference it during integration tests.
+    port: 5173
+  }
+});

--- a/docs/DeveloperExamTemplate.md
+++ b/docs/DeveloperExamTemplate.md
@@ -1,0 +1,95 @@
+# Developer Exam Template
+
+เอกสารฉบับนี้อธิบายโครงสร้าง Template สำหรับการสอบ Developer ที่ครอบคลุมทั้งฝั่ง Front-end, Back-end, Database และ API เพื่อให้สามารถนำไปประยุกต์ใช้ได้อย่างรวดเร็ว
+
+## โครงสร้างโดยรวม
+
+```
+DeveloperExamTemplate/
+├── frontend/
+├── backend/
+├── database/
+└── api/
+```
+
+แต่ละโฟลเดอร์แยกหน้าที่ชัดเจนเพื่อให้ผู้เข้าสอบสามารถโฟกัสกับภารกิจของตนเองได้
+
+---
+
+## Front-end
+
+* **เทคโนโลยีหลัก:** React + Vite
+* **ไฟล์สำคัญ:**
+  * `frontend/index.html` – จุดเริ่มต้นของแอปพลิเคชัน
+  * `frontend/src/main.jsx` – กำหนดการเรนเดอร์คอมโพเนนต์หลักเข้าสู่ DOM
+  * `frontend/src/App.jsx` – ตัวอย่างการดึงข้อมูลจาก API, จัดการ state, และแสดงผล
+  * `frontend/src/components/TaskForm.jsx` และ `frontend/src/components/TaskList.jsx` – แยกความรับผิดชอบของฟอร์มและรายการงาน
+* **แนวทางการต่อยอด:**
+  * เพิ่มระบบ Routing ด้วย React Router
+  * เชื่อมต่อ State Management ภายนอก เช่น Redux หรือ Zustand
+  * เพิ่มชุดทดสอบด้วย Vitest และ React Testing Library
+
+---
+
+## Back-end
+
+* **เทคโนโลยีหลัก:** Node.js + Express
+* **ไฟล์สำคัญ:**
+  * `backend/server.js` – ตั้งค่าเซิร์ฟเวอร์ Express และเชื่อมต่อ Route ต่าง ๆ
+  * `backend/routes/taskRoutes.js` – กำหนด Endpoints สำหรับงาน (Task)
+  * `backend/controllers/taskController.js` – จัดการลอจิกของการรับ/ส่งข้อมูล
+  * `backend/models/taskModel.js` และ `backend/models/db.js` – ติอต่อฐานข้อมูล PostgreSQL ผ่าน pg Pool
+* **แนวทางการต่อยอด:**
+  * เพิ่ม Middleware สำหรับ Authentication/Authorization
+  * เขียน Unit Test ด้วย Vitest และ Integration Test ด้วย Supertest
+  * แยก Service Layer เพื่อรองรับลอจิกที่ซับซ้อนขึ้น
+
+---
+
+## Database
+
+* **เทคโนโลยีหลัก:** PostgreSQL
+* **ไฟล์สำคัญ:**
+  * `database/schema.sql` – สคริปต์สำหรับสร้างตาราง `tasks`
+  * `database/seed.sql` – ข้อมูลตัวอย่างสำหรับเริ่มต้นระบบอย่างรวดเร็ว
+* **แนวทางการต่อยอด:**
+  * เพิ่มตารางอื่น ๆ เช่น `users`, `submissions`
+  * ผูก Constraint และ Index เพิ่มเติมเพื่อรองรับปริมาณข้อมูลมากขึ้น
+  * ตั้งค่าเครื่องมือ Migration เช่น Prisma หรือ Knex
+
+---
+
+## API
+
+* **ไฟล์สำคัญ:**
+  * `api/tasks.http` – ตัวอย่างคำสั่ง HTTP ที่ใช้ทดสอบ API ด้วย REST Client
+* **Endpoints ที่มีให้:**
+  * `GET /api/health` – ตรวจสอบสถานะเซิร์ฟเวอร์
+  * `GET /api/tasks` – ดึงรายการงานทั้งหมด
+  * `POST /api/tasks` – สร้างงานใหม่โดยรับค่า `title` และ `description`
+* **แนวทางการต่อยอด:**
+  * เพิ่มการแก้ไข (`PUT /api/tasks/:id`) และลบงาน (`DELETE /api/tasks/:id`)
+  * รองรับ Query Parameters สำหรับการค้นหาและกรองข้อมูล
+  * ออกแบบเอกสาร API ด้วย OpenAPI/Swagger
+
+---
+
+## การเริ่มต้นใช้งานอย่างรวดเร็ว
+
+1. สร้างฐานข้อมูลตามไฟล์ `database/schema.sql` และเติมข้อมูลจาก `database/seed.sql`
+2. คัดลอกไฟล์ `backend/.env.example` เป็น `.env` และแก้ไขค่าให้ตรงกับเครื่องของคุณ
+3. ติดตั้ง Dependencies ของแต่ละส่วนด้วย `npm install` ภายในโฟลเดอร์ `frontend` และ `backend`
+4. รัน Back-end ด้วย `npm run dev` ในโฟลเดอร์ `backend`
+5. รัน Front-end ด้วย `npm run dev` ในโฟลเดอร์ `frontend` และเปิดเบราว์เซอร์ที่ http://localhost:5173
+
+---
+
+## เคล็ดลับสำหรับผู้ออกข้อสอบ
+
+* กำหนดโจทย์เพิ่มเติม เช่น การจัดการสถานะงาน (Done/In Progress), ระบบผู้ใช้, หรือการแสดงผลกราฟ
+* เพิ่ม Test Case อัตโนมัติเพื่อตรวจสอบผลงานของผู้เข้าสอบได้อย่างรวดเร็ว
+* ปรับแต่งเอกสารนี้ให้สอดคล้องกับเกณฑ์การประเมินขององค์กร
+
+---
+
+ขอให้สนุกกับการสร้างแบบทดสอบ และหวังว่า Template นี้จะช่วยให้การจัดสอบเป็นเรื่องง่ายขึ้น!


### PR DESCRIPTION
## Summary
- add a React front-end template that demonstrates task creation, API calls, and component structure
- add an Express back-end skeleton with validation, PostgreSQL models, and routing for task resources
- provide database schema/seed scripts, example API requests, and documentation describing the template structure

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6904833d8ca0832694459d194eb324a4